### PR TITLE
Validate plugin from the packer-sdc plugin-validate command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,9 +18,7 @@ builds:
     hooks:
       post:
         # This will check plugin compatibility against latest version of Packer
-        - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
-            packer-plugins-check -load={{ .Name }}
+        - cmd: make plugin-check
           dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,16 +10,13 @@ before:
     # As part of the release doc files are included as a separate deliverable for
     # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
     - make ci-release-docs
+    # Check plugin compatibility with required version of the Packer SDK
+    - make plugin-check
 builds:
   # A separated build to run the packer-plugins-check only once for a linux_amd64 binary
   -
     id: plugin-check
     mod_timestamp: '{{ .CommitTimestamp }}'
-    hooks:
-      post:
-        # This will check plugin compatibility against latest version of Packer
-        - cmd: make plugin-check
-          dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,7 @@ BINARY=packer-plugin-${NAME}
 
 COUNT?=1
 TEST?=$(shell go list ./...)
+HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
 
 .PHONY: dev
 
@@ -13,21 +14,23 @@ dev: build
 	@mkdir -p ~/.packer.d/plugins/
 	@mv ${BINARY} ~/.packer.d/plugins/${BINARY}
 
-run-example: dev
-	@packer build ./example
+test:
+	@go test -race -count $(COUNT) $(TEST) -timeout=3m
 
-install-gen-deps: ## Install dependencies for code generation
-	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest
+install-packer-sdc: ## Install packer sofware development command
+	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
-ci-release-docs: install-gen-deps
+ci-release-docs: install-packer-sdc
 	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst docs/
 	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
 
-test:
-	@go test -count $(COUNT) $(TEST) -timeout=3m
-
-generate: install-gen-deps
-	go generate ./...
+plugin-check: install-packer-sdc build
+	@packer-sdc plugin-check ${BINARY}
 
 testacc: dev
 	@PACKER_ACC=1 go test -count $(COUNT) -v $(TEST) -timeout=120m
+
+generate: install-packer-sdc
+	@go generate ./...
+	packer-sdc renderdocs -src ./docs -dst ./.docs -partials ./docs-partials
+	# checkout the .docs folder for a preview of the docs

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/hcl/v2 v2.10.1
-	github.com/hashicorp/packer-plugin-sdk v0.2.7
+	github.com/hashicorp/packer-plugin-sdk v0.2.8
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7
 	github.com/zclconf/go-cty v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/packer-plugin-sdk v0.2.7 h1:L7mfLg+gGnqN3z8vEG4YojVsbhYJrNcimvOSIuCN6qA=
 github.com/hashicorp/packer-plugin-sdk v0.2.7/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
+github.com/hashicorp/packer-plugin-sdk v0.2.8 h1:743RCKQmpiiCo4R+Xs0fO1fMNkpi4VdGfX0tZ6aNdUg=
+github.com/hashicorp/packer-plugin-sdk v0.2.8/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/serf v0.9.5 h1:EBWvyu9tcRszt3Bxp3KNssBMP1KuHWyO51lz9+786iM=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f/go.mod h1:euTFbi2YJgwcju3imEt919lhJKF68nN1cQPq3aA+kBE=

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
 github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC7AO2g=
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/hashicorp/packer-plugin-sdk v0.2.7 h1:L7mfLg+gGnqN3z8vEG4YojVsbhYJrNcimvOSIuCN6qA=
-github.com/hashicorp/packer-plugin-sdk v0.2.7/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/packer-plugin-sdk v0.2.8 h1:743RCKQmpiiCo4R+Xs0fO1fMNkpi4VdGfX0tZ6aNdUg=
 github.com/hashicorp/packer-plugin-sdk v0.2.8/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/serf v0.9.5 h1:EBWvyu9tcRszt3Bxp3KNssBMP1KuHWyO51lz9+786iM=


### PR DESCRIPTION
👋🏼  going forward, the `packer-sdc plugin-check` command will be the command to check plugins, this updates this and makes sure we are using the correct version for that.

* Use packer-sdc plugin-check from imported sdk in makefile
* make sure we have the most recent sdk
* make goreleaser use that too