### PR TITLE
ci: change gpg action import because of deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
https://github.com/hashicorp/ghaction-import-gpg is marked as deprecated