### PR TITLE
Register plug-in as Packer integration

### DIFF
--- a/.github/workflows/ensure-docs-compiled.yaml
+++ b/.github/workflows/ensure-docs-compiled.yaml
@@ -9,14 +9,14 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v4
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
 

--- a/.github/workflows/ensure-docs-compiled.yaml
+++ b/.github/workflows/ensure-docs-compiled.yaml
@@ -1,0 +1,22 @@
+name: Ensure Docs are Compiled
+on:
+  push:
+jobs:
+  ensure-docs-compiled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+      - shell: bash
+        run: make build-docs
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make build-docs', and commit the result to resolve this error."
+            exit 1
+          fi
+

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -1,10 +1,12 @@
+# Manual release workflow is used for deploying documentation updates
+# on the specified branch without making an official plugin release. 
 name: Notify Integration Release (Manual)
 on:
   workflow_dispatch:
     inputs:
       version:
         description: "The release version (semver)"
-        default: 0.0.1
+        default: 1.0.0
         required: false
       branch:
         description: "A branch or SHA"
@@ -15,32 +17,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.inputs.branch }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
       # Perform the Release
       - name: Checkout integration-release-action
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           repository: hashicorp/integration-release-action
           path: ./integration-release-action
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: 'packer/BrandonRomano/scaleway'
+          # The integration identifier will be used by the Packer team to register the integration
+          # the expected format is packer/<GitHub Org Name>/<plugin-name>
+          integration_identifier: "packer/hashicorp/scaffolding"
           release_version: ${{ github.event.inputs.version }}
           release_sha: ${{ github.event.inputs.branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -1,0 +1,46 @@
+name: Notify Integration Release (Manual)
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The release version (semver)"
+        default: 0.0.1
+        required: false
+      branch:
+        description: "A branch or SHA"
+        default: 'main'
+        required: false
+jobs:
+  notify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      # Ensure that Docs are Compiled
+      - uses: actions/setup-go@v4
+      - shell: bash
+        run: make build-docs
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make build-docs', and commit the result to resolve this error."
+            exit 1
+          fi
+      # Perform the Release
+      - name: Checkout integration-release-action
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          repository: hashicorp/integration-release-action
+          path: ./integration-release-action
+      - name: Notify Release
+        uses: ./integration-release-action
+        with:
+          integration_identifier: 'packer/BrandonRomano/scaleway'
+          release_version: ${{ github.event.inputs.version }}
+          release_sha: ${{ github.event.inputs.branch }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           # The integration identifier will be used by the Packer team to register the integration
           # the expected format is packer/<GitHub Org Name>/<plugin-name>
-          integration_identifier: "packer/hashicorp/scaffolding"
+          integration_identifier: "packer/scaleway/scaleway"
           release_version: ${{ github.event.inputs.version }}
           release_sha: ${{ github.event.inputs.branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -3,38 +3,52 @@ on:
   push:
     tags:
       - '*.*.*'   # Proper releases
-      - '*.*.*-*' # Pre releases
 jobs:
+  strip-version:
+    runs-on: ubuntu-latest
+    outputs:
+      packer-version: ${{ steps.strip.outputs.packer-version }}
+    steps:
+      - name: Strip leading v from version tag
+        id: strip
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          echo "packer-version=$(echo "$REF" | sed -E 's/v?([0-9]+\.[0-9]+\.[0-9]+)/\1/')" >> "$GITHUB_OUTPUT"
   notify-release:
+    needs:
+      - strip-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.ref }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
       # Perform the Release
       - name: Checkout integration-release-action
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           repository: hashicorp/integration-release-action
           path: ./integration-release-action
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: 'packer/BrandonRomano/scaleway'
-          release_version: ${{ github.ref_name }}
+          # The integration identifier will be used by the Packer team to register the integration
+          # the expected format is packer/<GitHub Org Name>/<plugin-name>
+          integration_identifier: "packer/hashicorp/scaffolding"
+          release_version: ${{ needs.strip-version.outputs.packer-version }}
           release_sha: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -1,0 +1,40 @@
+name: Notify Integration Release (Tag)
+on:
+  push:
+    tags:
+      - '*.*.*'   # Proper releases
+      - '*.*.*-*' # Pre releases
+jobs:
+  notify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ github.ref }}
+      # Ensure that Docs are Compiled
+      - uses: actions/setup-go@v4
+      - shell: bash
+        run: make build-docs
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make build-docs', and commit the result to resolve this error."
+            exit 1
+          fi
+      # Perform the Release
+      - name: Checkout integration-release-action
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          repository: hashicorp/integration-release-action
+          path: ./integration-release-action
+      - name: Notify Release
+        uses: ./integration-release-action
+        with:
+          integration_identifier: 'packer/BrandonRomano/scaleway'
+          release_version: ${{ github.ref_name }}
+          release_sha: ${{ github.ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -2,7 +2,7 @@ name: Notify Integration Release (Tag)
 on:
   push:
     tags:
-      - '*.*.*'   # Proper releases
+      - 'v*'   # Proper releases
 jobs:
   strip-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           # The integration identifier will be used by the Packer team to register the integration
           # the expected format is packer/<GitHub Org Name>/<plugin-name>
-          integration_identifier: "packer/hashicorp/scaffolding"
+          integration_identifier: "packer/scaleway/scaleway"
           release_version: ${{ needs.strip-version.outputs.packer-version }}
           release_sha: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -1,20 +1,9 @@
-# Scaleway Plugin
-
 The [Scaleway](https://www.scaleway.com) Packer plugin provides a builder for building images in
 Scaleway.
 
-## Installation
+### Installation
 
-### Using pre-built releases
-
-#### Using the `packer init` command
-
-Starting from version 1.7, Packer supports a new `packer init` command allowing
-automatic installation of Packer plugins. Read the
-[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
-
-To install this plugin, copy and paste this code into your Packer configuration.
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://www.packer.io/docs/commands/init).
 
 ```hcl
 packer {
@@ -27,8 +16,7 @@ packer {
 }
 ```
 
-
-#### Using the `packer plugins install` command
+Alternatively, you can use `packer plugins install` to manage installation of this plugin.
 
 ```sh
 $ packer plugins install github.com/scaleway/scaleway v1.0.x
@@ -38,33 +26,11 @@ This command will install the most recent compatible Scaleway Packer plugin matc
 version constraint. If the version constraint is omitted, the most recent
 version of the plugin will be installed.
 
+### Components
 
-#### Manual installation
+#### Builders
 
-You can find pre-built binary releases of the plugin [here](https://github.com/scaleway/packer-plugin-scaleway/releases).
-Once you have downloaded the latest archive corresponding to your target OS,
-uncompress it to retrieve the plugin binary file corresponding to your platform.
-To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
-
-#### From Source
-
-If you prefer to build the plugin from sources, clone the GitHub repository
-locally and run the command `go build` from the root
-directory. Upon successful compilation, a `packer-plugin-scaleway` plugin
-binary file can be found in the root directory.
-To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
-
-## Plugin Contents
-
-The Scaleway plugin is intended as a starting point for creating Packer plugins, containing:
-
-### Builders
-
-- [builder](/docs/builders/scaleway.mdx) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
+- [scaleway](/packer/integrations/scaleway/latest/components/builder/scaleway) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
 The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. 
 This reusable image can then be used as the foundation of new servers that are launched within Scaleway.
 

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -30,7 +30,7 @@ version of the plugin will be installed.
 
 #### Builders
 
-- [scaleway](/packer/integrations/scaleway/latest/components/builder/scaleway) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
+- [scaleway](/packer/integrations/scaleway/scaleway/latest/components/builder/scaleway) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
 The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. 
 This reusable image can then be used as the foundation of new servers that are launched within Scaleway.
 

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -1,0 +1,70 @@
+# Scaleway Plugin
+
+The [Scaleway](https://www.scaleway.com) Packer plugin provides a builder for building images in
+Scaleway.
+
+## Installation
+
+### Using pre-built releases
+
+#### Using the `packer init` command
+
+Starting from version 1.7, Packer supports a new `packer init` command allowing
+automatic installation of Packer plugins. Read the
+[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
+
+To install this plugin, copy and paste this code into your Packer configuration.
+Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+
+```hcl
+packer {
+  required_plugins {
+    scaleway = {
+      version = ">= 1.0.5"
+      source  = "github.com/scaleway/scaleway"
+    }
+  }
+}
+```
+
+
+#### Using the `packer plugins install` command
+
+```sh
+$ packer plugins install github.com/scaleway/scaleway v1.0.x
+```
+
+This command will install the most recent compatible Scaleway Packer plugin matching
+version constraint. If the version constraint is omitted, the most recent
+version of the plugin will be installed.
+
+
+#### Manual installation
+
+You can find pre-built binary releases of the plugin [here](https://github.com/scaleway/packer-plugin-scaleway/releases).
+Once you have downloaded the latest archive corresponding to your target OS,
+uncompress it to retrieve the plugin binary file corresponding to your platform.
+To install the plugin, please follow the Packer documentation on
+[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+
+#### From Source
+
+If you prefer to build the plugin from sources, clone the GitHub repository
+locally and run the command `go build` from the root
+directory. Upon successful compilation, a `packer-plugin-scaleway` plugin
+binary file can be found in the root directory.
+To install the compiled plugin, please follow the official Packer documentation
+on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+
+## Plugin Contents
+
+The Scaleway plugin is intended as a starting point for creating Packer plugins, containing:
+
+### Builders
+
+- [builder](/docs/builders/scaleway.mdx) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
+The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. 
+This reusable image can then be used as the foundation of new servers that are launched within Scaleway.
+

--- a/.web-docs/components/builder/scaleway/README.md
+++ b/.web-docs/components/builder/scaleway/README.md
@@ -10,25 +10,6 @@ of new servers that are launched within Scaleway.
 The builder does _not_ manage snapshots. Once it creates an image, it is up to
 you to use it or delete it.
 
-## Installation
-
-To install this plugin using Packer v1.7.0 or later, copy and paste this code
-into your Packer configuration.
-
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
-
-
-```hcl
-packer {
-  required_plugins {
-    scaleway = {
-      version = ">= 1.0.5"
-      source  = "github.com/scaleway/scaleway"
-    }
-  }
-}
-```
-
 ## Configuration Reference
 
 There are many configuration options available for the builder. They are

--- a/.web-docs/components/builder/scaleway/README.md
+++ b/.web-docs/components/builder/scaleway/README.md
@@ -1,0 +1,193 @@
+Type: `scaleway`
+Artifact BuilderId: `hashicorp.scaleway`
+
+The `scaleway` Packer builder is able to create new images for use with
+[Scaleway](https://www.scaleway.com). The builder takes a source image, runs
+any provisioning necessary on the image after launching it, then snapshots it
+into a reusable image. This reusable image can then be used as the foundation
+of new servers that are launched within Scaleway.
+
+The builder does _not_ manage snapshots. Once it creates an image, it is up to
+you to use it or delete it.
+
+## Installation
+
+To install this plugin using Packer v1.7.0 or later, copy and paste this code
+into your Packer configuration.
+
+Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+
+
+```hcl
+packer {
+  required_plugins {
+    scaleway = {
+      version = ">= 1.0.5"
+      source  = "github.com/scaleway/scaleway"
+    }
+  }
+}
+```
+
+## Configuration Reference
+
+There are many configuration options available for the builder. They are
+segmented below into two categories: required and optional parameters. Within
+each category, the available configuration keys are alphabetized.
+
+In addition to the options listed here, a
+[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+- `ssh_private_key_file` (string) - Path to a PEM encoded private key file to use to authenticate with SSH.
+  The `~` can be used in path and will be expanded to the home directory
+  of current user.
+
+
+### Required:
+
+<!-- Code generated from the comments of the Config struct in builder/scaleway/config.go; DO NOT EDIT MANUALLY -->
+
+- `access_key` (string) - The AccessKey corresponding to the secret key.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
+  It can also be specified via the environment variable SCW_ACCESS_KEY.
+
+- `secret_key` (string) - The SecretKey to authenticate against the Scaleway API.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
+  It can also be specified via the environment variable SCW_SECRET_KEY.
+
+- `project_id` (string) - The Project ID in which the instances, volumes and snapshots will be created.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
+  It can also be specified via the environment variable SCW_DEFAULT_PROJECT_ID.
+
+- `zone` (string) - The Zone in which the instances, volumes and snapshots will be created.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
+  It can also be specified via the environment variable SCW_DEFAULT_ZONE
+
+- `image` (string) - The UUID of the base image to use. This is the image
+  that will be used to launch a new server and provision it. See
+  the images list
+  get the complete list of the accepted image UUID.
+  The marketplace image label (eg `ubuntu_focal`) also works.
+
+- `commercial_type` (string) - The name of the server commercial type:
+  DEV1-S, DEV1-M, DEV1-L, DEV1-XL,
+  PLAY2-PICO, PLAY2-NANO, PLAY2-MICRO,
+  PRO2-XXS, PRO2-XS, PRO2-S, PRO2-M, PRO2-L,
+  GP1-XS, GP1-S, GP1-M, GP1-L, GP1-XL,
+  ENT1-XXS, ENT1-XS, ENT1-S, ENT1-M, ENT1-L, ENT1-XL, ENT1-2XL,
+  GPU-3070-S, RENDER-S, STARDUST1-S,
+
+<!-- End of code generated from the comments of the Config struct in builder/scaleway/config.go; -->
+
+
+### Optional:
+
+<!-- Code generated from the comments of the Config struct in builder/scaleway/config.go; DO NOT EDIT MANUALLY -->
+
+- `api_url` (string) - The Scaleway API URL to use
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
+  It can also be specified via the environment variable SCW_API_URL
+
+- `image_size_in_gb` (int32) - The Image size in GB. Will only work for images based on block volumes.
+
+- `snapshot_name` (string) - The name of the resulting snapshot that will
+  appear in your account. Default packer-TIMESTAMP
+
+- `image_name` (string) - The name of the resulting image that will appear in
+  your account. Default packer-TIMESTAMP
+
+- `server_name` (string) - The name assigned to the server. Default
+  packer-UUID
+
+- `bootscript` (string) - The id of an existing bootscript to use when
+  booting the server.
+
+- `boottype` (string) - The type of boot, can be either local or
+  bootscript, Default bootscript
+
+- `remove_volume` (bool) - Remove Volume
+
+- `cleanup_machine_related_data` (string) - This value allows the user to remove information
+  that is particular to the instance used to build the image
+
+- `snapshot_creation_timeout` (duration string | ex: "1h5m2s") - The time to wait for snapshot creation. Defaults to "1h"
+
+- `image_creation_timeout` (duration string | ex: "1h5m2s") - The time to wait for image creation. Defaults to "1h"
+
+- `server_creation_timeout` (duration string | ex: "1h5m2s") - The time to wait for server creation. Defaults to "10m"
+
+- `server_shutdown_timeout` (duration string | ex: "1h5m2s") - The time to wait for server shutdown. Defaults to "10m"
+
+- `user_data` (map[string]string) - User data to apply when launching the instance
+
+- `user_data_timeout` (duration string | ex: "1h5m2s") - A custom timeout for user data to assure its completion. Defaults to "0s"
+
+- `api_token` (string) - The token to use to authenticate with your account.
+  It can also be specified via environment variable SCALEWAY_API_TOKEN. You
+  can see and generate tokens in the "Credentials"
+  section of the control panel.
+  Deprecated, use SecretKey instead
+
+- `organization_id` (string) - The organization id to use to identify your
+  organization. It can also be specified via environment variable
+  SCALEWAY_ORGANIZATION. Your organization id is available in the
+  "Account" section of the
+  control panel.
+  Previously named: api_access_key with environment variable: SCALEWAY_API_ACCESS_KEY
+  Deprecated, use ProjectID instead
+
+- `region` (string) - The name of the region to launch the server in (par1
+  or ams1). Consequently, this is the region where the snapshot will be
+  available.
+  Deprecated, use Zone instead
+
+<!-- End of code generated from the comments of the Config struct in builder/scaleway/config.go; -->
+
+
+## Basic Example
+
+Here is a basic example. It is completely valid as soon as you enter your own
+access tokens:
+
+**HCL2**
+
+```hcl
+source "scaleway" "example" {
+  project_id = "YOUR PROJECT ID"
+  access_key = "YOUR ACCESS KEY"
+  secret_key = "YOUR SECRET KEY"
+  image = "UUID OF THE BASE IMAGE"
+  zone = "fr-par-1"
+  commercial_type = "DEV1-S"
+  ssh_username = "root"
+  ssh_private_key_file = "~/.ssh/id_rsa"
+}
+
+build {
+  sources = ["source.scaleway.example"]
+}
+```
+
+
+**JSON**
+
+    ```json
+    {
+        "type": "scaleway",
+        "project_id": "YOUR PROJECT ID",
+        "access_key": "YOUR ACCESS KEY",
+        "secret_key": "YOUR SECRET KEY",
+        "image": "UUID OF THE BASE IMAGE",
+        "zone": "fr-par-1",
+        "commercial_type": "DEV1-S",
+        "ssh_username": "root",
+        "ssh_private_key_file": "~/.ssh/id_rsa"
+    }
+    ```
+
+
+When you do not specify the `ssh_private_key_file`, a temporary SSH keypair
+is generated to connect the server. This key will only allow the `root` user to
+connect the server.

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -3,7 +3,7 @@
 integration {
   name = "Scaleway"
   description = "TODO"
-  identifier = "packer/BrandonRomano/scaleway"
+  identifier = "packer/scaleway/scaleway"
   component {
     type = "builder"
     name = "Scaleway"

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -1,0 +1,12 @@
+# For full specification on the configuration of this file visit:
+# https://github.com/hashicorp/integration-template#metadata-configuration
+integration {
+  name = "Scaleway"
+  description = "TODO"
+  identifier = "packer/BrandonRomano/scaleway"
+  component {
+    type = "builder"
+    name = "Scaleway"
+    slug = "scaleway"
+  }
+}

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -2,7 +2,7 @@
 # https://github.com/hashicorp/integration-template#metadata-configuration
 integration {
   name = "Scaleway"
-  description = "TODO"
+  description = "Create new images for use with Scaleway."
   identifier = "packer/scaleway/scaleway"
   component {
     type = "builder"

--- a/.web-docs/scripts/compile-to-webdocs.sh
+++ b/.web-docs/scripts/compile-to-webdocs.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# Converts the folder name that the component documentation file
+# is stored in into the integration slug of the component.
+componentTypeFromFolderName() {
+    if [[ "$1" = "builders" ]]; then
+        echo "builder"
+    elif [[ "$1" = "provisioners" ]]; then
+        echo "provisioner"
+    elif [[ "$1" = "post-processors" ]]; then
+        echo "post-processor"
+    elif [[ "$1" = "datasources" ]]; then
+        echo "data-source"
+    else
+        echo ""
+    fi
+}
+
+# $1: The content to adjust links
+# $2: The organization of the integration
+rewriteLinks() {
+  local result="$1"
+  local organization="$2"
+
+  urlSegment="([^/]+)"
+  urlAnchor="(#[^/]+)"
+
+  # Rewrite Component Index Page links to the Integration root page.
+  #
+  #                    (\1)     (\2)      (\3)
+  # /packer/plugins/datasources/amazon#anchor-tag-->
+  # /packer/integrations/hashicorp/amazon#anchor-tag
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\3\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+
+  # Rewrite Component links to the Integration component page
+  #
+  #                    (\1)      (\2)       (\3)       (\4)
+  # /packer/plugins/datasources/amazon/parameterstore#anchor-tag -->
+  # /packer/integrations/{organization}/amazon/latest/components/datasources/parameterstore
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\/latest\/components\/\1\/\3\4\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+  # Rewrite the Component URL segment from the Packer Plugin format
+  # to the Integrations format
+  result="$(echo "$result" \
+      | sed "s/\/datasources\//\/data-source\//g" \
+      | sed "s/\/builders\//\/builder\//g" \
+      | sed "s/\/post-processors\//\/post-processor\//g" \
+      | sed "s/\/provisioners\//\/provisioner\//g" \
+  )"
+
+  echo "$result"
+}
+
+# $1: Docs Dir
+# $2: Web Docs Dir
+# $3: Component File
+# $4: The org of the integration
+processComponentFile() {
+    local docsDir="$1"
+    local webDocsDir="$2"
+    local componentFile="$3"
+
+    local escapedDocsDir="$(echo "$docsDir" | sed 's/\//\\\//g' | sed 's/\./\\\./g')"
+    local componentTypeAndSlug="$(echo "$componentFile" | sed "s/$escapedDocsDir\///g" | sed 's/\.mdx//g')"
+
+    # Parse out the Component Slug & Component Type
+    local componentSlug="$(echo "$componentTypeAndSlug" | cut -d'/' -f 2)"
+    local componentType="$(componentTypeFromFolderName "$(echo "$componentTypeAndSlug" | cut -d'/' -f 1)")"
+    if [[ "$componentType" = "" ]]; then
+        echo "Failed to process '$componentFile', unexpected folder name."
+        echo "Documentation for components must be stored in one of:"
+        echo "builders, provisioners, post-processors, datasources"
+        exit 1
+    fi
+
+
+    # Calculate the location of where this file will ultimately go
+    local webDocsFolder="$webDocsDir/components/$componentType/$componentSlug"
+    mkdir -p "$webDocsFolder"
+    local webDocsFile="$webDocsFolder/README.md"
+    local webDocsFileTmp="$webDocsFolder/README.md.tmp"
+
+    # Copy over the file to its webDocsFile location
+    cp "$componentFile" "$webDocsFile"
+
+    # Remove the Header
+    local lastMetadataLine="$(grep -n -m 2 '^\-\-\-' "$componentFile" | tail -n1 | cut -d':' -f1)"
+    cat "$webDocsFile" | tail -n +"$(($lastMetadataLine+2))"  > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Remove the top H1, as this will be added automatically on the web
+    cat "$webDocsFile" | tail -n +3 > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Rewrite Links
+    rewriteLinks "$(cat "$webDocsFile")" "$4" > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+}
+
+# Compiles the Packer SDC compiled docs folder down
+# to a integrations-compliant folder (web docs)
+#
+# $1: The directory of the plugin
+# $2: The directory of the SDC compiled docs files
+# $3: The output directory to place the web-docs files
+# $4: The org of the integration
+compileWebDocs() {
+  local docsDir="$1/$2"
+  local webDocsDir="$1/$3"
+
+  echo "Compiling MDX docs in '$2' to Markdown in '$3'..."
+  # Create the web-docs directory if it hasn't already been created
+  mkdir -p "$webDocsDir"
+
+  # Copy the README over
+  cp "$docsDir/README.md" "$webDocsDir/README.md"
+
+  # Process all MDX component files (exclude index files, which are unsupported)
+  for file in $(find "$docsDir" | grep "$docsDir/.*/.*\.mdx" | grep --invert-match "index.mdx"); do
+    processComponentFile "$docsDir" "$webDocsDir" "$file" "$4"
+  done
+}
+
+compileWebDocs "$1" "$2" "$3" "$4"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,3 +37,9 @@ generate: install-packer-sdc
 
 install-plugin:
 	@packer plugins install github.com/scaleway/scaleway
+
+build-docs: install-packer-sdc
+	@if [ -d ".docs" ]; then rm -r ".docs"; fi
+	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
+	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "BrandonRomano"
+	@rm -r ".docs"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,5 +41,5 @@ install-plugin:
 build-docs: install-packer-sdc
 	@if [ -d ".docs" ]; then rm -r ".docs"; fi
 	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
-	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "BrandonRomano"
+	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "scaleway"
 	@rm -r ".docs"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,10 +20,6 @@ test:
 install-packer-sdc: ## Install packer sofware development command
 	go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
-ci-release-docs: install-packer-sdc
-	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst docs/
-	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
-
 plugin-check: install-packer-sdc build
 	@packer-sdc plugin-check ${BINARY}
 
@@ -32,14 +28,11 @@ testacc: dev
 
 generate: install-packer-sdc
 	@go generate ./...
-	packer-sdc renderdocs -src ./docs -dst ./.docs -partials ./docs-partials
+	@if [ -d ".docs" ]; then rm -r ".docs"; fi
+	packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
+	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "scaleway"
+	@rm -r ".docs"
 	# checkout the .docs folder for a preview of the docs
 
 install-plugin:
 	@packer plugins install github.com/scaleway/scaleway
-
-build-docs: install-packer-sdc
-	@if [ -d ".docs" ]; then rm -r ".docs"; fi
-	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
-	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "scaleway"
-	@rm -r ".docs"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,9 @@
-# Scaleway Plugin
-
 The [Scaleway](https://www.scaleway.com) Packer plugin provides a builder for building images in
 Scaleway.
 
-## Installation
+### Installation
 
-### Using pre-built releases
-
-#### Using the `packer init` command
-
-Starting from version 1.7, Packer supports a new `packer init` command allowing
-automatic installation of Packer plugins. Read the
-[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
-
-To install this plugin, copy and paste this code into your Packer configuration.
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://www.packer.io/docs/commands/init).
 
 ```hcl
 packer {
@@ -27,8 +16,7 @@ packer {
 }
 ```
 
-
-#### Using the `packer plugins install` command
+Alternatively, you can use `packer plugins install` to manage installation of this plugin.
 
 ```sh
 $ packer plugins install github.com/scaleway/scaleway v1.0.x
@@ -38,33 +26,11 @@ This command will install the most recent compatible Scaleway Packer plugin matc
 version constraint. If the version constraint is omitted, the most recent
 version of the plugin will be installed.
 
+### Components
 
-#### Manual installation
+#### Builders
 
-You can find pre-built binary releases of the plugin [here](https://github.com/scaleway/packer-plugin-scaleway/releases).
-Once you have downloaded the latest archive corresponding to your target OS,
-uncompress it to retrieve the plugin binary file corresponding to your platform.
-To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
-
-#### From Source
-
-If you prefer to build the plugin from sources, clone the GitHub repository
-locally and run the command `go build` from the root
-directory. Upon successful compilation, a `packer-plugin-scaleway` plugin
-binary file can be found in the root directory.
-To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
-
-## Plugin Contents
-
-The Scaleway plugin is intended as a starting point for creating Packer plugins, containing:
-
-### Builders
-
-- [builder](/docs/builders/scaleway.mdx) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
+- [scaleway](/packer/integrations/scaleway/latest/components/builder/scaleway) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
 The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. 
 This reusable image can then be used as the foundation of new servers that are launched within Scaleway.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ version of the plugin will be installed.
 
 #### Builders
 
-- [scaleway](/packer/integrations/scaleway/latest/components/builder/scaleway) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
+- [scaleway](/packer/integrations/scaleway/scaleway/latest/components/builder/scaleway) - The Scaleway Packer builder is able to create new images for use with Scaleway Compute Instance servers. 
 The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. 
 This reusable image can then be used as the foundation of new servers that are launched within Scaleway.
 

--- a/docs/builders/scaleway.mdx
+++ b/docs/builders/scaleway.mdx
@@ -28,7 +28,7 @@ of new servers that are launched within Scaleway.
 The builder does _not_ manage snapshots. Once it creates an image, it is up to
 you to use it or delete it.
 
-### Installation
+## Installation
 
 To install this plugin using Packer v1.7.0 or later, copy and paste this code
 into your Packer configuration.
@@ -73,8 +73,7 @@ can also be supplied to override the typical auto-generated key:
 Here is a basic example. It is completely valid as soon as you enter your own
 access tokens:
 
-<Tabs>
-<Tab heading="HCL2">
+**HCL2**
 
 ```hcl
 source "scaleway" "example" {
@@ -93,9 +92,8 @@ build {
 }
 ```
 
-</Tab>
 
-<Tab heading="JSON">
+**JSON**
 
     ```json
     {
@@ -111,8 +109,6 @@ build {
     }
     ```
 
-</Tab>
-</Tabs>
 
 When you do not specify the `ssh_private_key_file`, a temporary SSH keypair
 is generated to connect the server. This key will only allow the `root` user to

--- a/docs/builders/scaleway.mdx
+++ b/docs/builders/scaleway.mdx
@@ -28,25 +28,6 @@ of new servers that are launched within Scaleway.
 The builder does _not_ manage snapshots. Once it creates an image, it is up to
 you to use it or delete it.
 
-## Installation
-
-To install this plugin using Packer v1.7.0 or later, copy and paste this code
-into your Packer configuration.
-
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
-
-
-```hcl
-packer {
-  required_plugins {
-    scaleway = {
-      version = ">= 1.0.5"
-      source  = "github.com/scaleway/scaleway"
-    }
-  }
-}
-```
-
 ## Configuration Reference
 
 There are many configuration options available for the builder. They are


### PR DESCRIPTION
:wave: fellow Packer maintainer working on migrating your plugin to the Packer integration framework.

This change takes the necessary steps to register this plugin as an official Packer integration.
Integrations can be found on the Packer integration portal at https://developer.hashicorp.com/packer/integrations.

---

The pull-request consists of the following changes:

- Adds controlling, metadata file, `metadata.hcl` for registering the plug-in and it components as integrations.
Details on the contents, along with a description of the attributes, can be found at https://github.com/hashicorp/integration-template.
- Adds the GitHub action workflows for triggering manual and automatic integration updates.
- Restructures the plug-in documentation to match the expected format of the integration framework.
- Adds a `.web-docs` directory for serving the fully render documentation as the integration docs.
- Adds the build-docs make target `make build-docs` for syncing changes to the `docs` directory to the `.web-docs` directory.

Changes to the integration docs can be made at plugin release via the `notify-integration-release-via-tag` workflow or
manually by running the `notify-integration-release-via-manual` workflow.

Details on how the Integration framework pipeline works can be found at https://github.com/hashicorp/packer/pull/12702

### TODOs
- [x] Open pull-request against external plugin.
- [ ] Update integration description [`.web-docs/metadata.hcl`](.web-docs/metadata.hcl).
- [ ] Packer team open internal pull-request to enable integration.
- [ ] Review plugin integration on Packer integration portal .... Iterate
