### PR TITLE
feat: add root_volume config and default to sbs volume type

### DIFF
--- a/.web-docs/components/builder/scaleway/README.md
+++ b/.web-docs/components/builder/scaleway/README.md
@@ -90,6 +90,8 @@ can also be supplied to override the typical auto-generated key:
 
 - `remove_volume` (bool) - RemoveVolume remove the temporary volumes created before running the server
 
+- `root_volume` (ConfigRootVolume) - RootVolumeType lets you configure the root volume
+
 - `block_volume` ([]ConfigBlockVolume) - BlockVolumes define block volumes attached to the server alongside the default volume
   See the [BlockVolumes](#block-volumes-configuration) documentation for fields.
 

--- a/builder/scaleway/api.go
+++ b/builder/scaleway/api.go
@@ -1,10 +1,10 @@
 package scaleway
 
 import (
+	_ "unsafe" // Import required for link
+
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
-
-	_ "unsafe"
 )
 
 //go:linkname createServer github.com/scaleway/scaleway-sdk-go/api/instance/v1.(*API).createServer

--- a/builder/scaleway/api.go
+++ b/builder/scaleway/api.go
@@ -1,0 +1,11 @@
+package scaleway
+
+import (
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+
+	_ "unsafe"
+)
+
+//go:linkname createServer github.com/scaleway/scaleway-sdk-go/api/instance/v1.(*API).createServer
+func createServer(*instance.API, *instance.CreateServerRequest, ...scw.RequestOption) (*instance.CreateServerResponse, error)

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -1,5 +1,5 @@
 //go:generate packer-sdc struct-markdown
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config,ConfigBlockVolume
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,ConfigBlockVolume,ConfigRootVolume
 
 package scaleway
 
@@ -29,6 +29,15 @@ const (
 	defaultUserDataWaitTimeout             = 0 * time.Second
 	defaultCleanupMachineRelatedDataStatus = "false"
 )
+
+type ConfigRootVolume struct {
+	// The type of the root volume
+	Type string `mapstructure:"type"`
+	// IOPS of the root volume if using SBS, will only affect runtime. Image's volumes cannot have a configured IOPS.
+	IOPS *uint32 `mapstructure:"iops"`
+	// Size of the root volume
+	SizeInGB uint64 `mapstructure:"size_in_gb"`
+}
 
 type ConfigBlockVolume struct {
 	// The name of the created volume
@@ -99,6 +108,9 @@ type Config struct {
 
 	// RemoveVolume remove the temporary volumes created before running the server
 	RemoveVolume bool `mapstructure:"remove_volume"`
+
+	// RootVolumeType lets you configure the root volume
+	RootVolume ConfigRootVolume `mapstructure:"root_volume" required:"false"`
 
 	// BlockVolumes define block volumes attached to the server alongside the default volume
 	// See the [BlockVolumes](#block-volumes-configuration) documentation for fields.

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	Bootscript                *string                 `mapstructure:"bootscript" required:"false" cty:"bootscript" hcl:"bootscript"`
 	BootType                  *string                 `mapstructure:"boottype" required:"false" cty:"boottype" hcl:"boottype"`
 	RemoveVolume              *bool                   `mapstructure:"remove_volume" cty:"remove_volume" hcl:"remove_volume"`
+	RootVolume                *FlatConfigRootVolume   `mapstructure:"root_volume" required:"false" cty:"root_volume" hcl:"root_volume"`
 	BlockVolumes              []FlatConfigBlockVolume `mapstructure:"block_volume" cty:"block_volume" hcl:"block_volume"`
 	CleanupMachineRelatedData *string                 `mapstructure:"cleanup_machine_related_data" required:"false" cty:"cleanup_machine_related_data" hcl:"cleanup_machine_related_data"`
 	SnapshotCreationTimeout   *string                 `mapstructure:"snapshot_creation_timeout" required:"false" cty:"snapshot_creation_timeout" hcl:"snapshot_creation_timeout"`
@@ -178,6 +179,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"bootscript":                   &hcldec.AttrSpec{Name: "bootscript", Type: cty.String, Required: false},
 		"boottype":                     &hcldec.AttrSpec{Name: "boottype", Type: cty.String, Required: false},
 		"remove_volume":                &hcldec.AttrSpec{Name: "remove_volume", Type: cty.Bool, Required: false},
+		"root_volume":                  &hcldec.BlockSpec{TypeName: "root_volume", Nested: hcldec.ObjectSpec((*FlatConfigRootVolume)(nil).HCL2Spec())},
 		"block_volume":                 &hcldec.BlockListSpec{TypeName: "block_volume", Nested: hcldec.ObjectSpec((*FlatConfigBlockVolume)(nil).HCL2Spec())},
 		"cleanup_machine_related_data": &hcldec.AttrSpec{Name: "cleanup_machine_related_data", Type: cty.String, Required: false},
 		"snapshot_creation_timeout":    &hcldec.AttrSpec{Name: "snapshot_creation_timeout", Type: cty.String, Required: false},
@@ -219,6 +221,33 @@ func (*FlatConfigBlockVolume) HCL2Spec() map[string]hcldec.Spec {
 		"snapshot_id": &hcldec.AttrSpec{Name: "snapshot_id", Type: cty.String, Required: false},
 		"size_in_gb":  &hcldec.AttrSpec{Name: "size_in_gb", Type: cty.Number, Required: false},
 		"iops":        &hcldec.AttrSpec{Name: "iops", Type: cty.Number, Required: false},
+	}
+	return s
+}
+
+// FlatConfigRootVolume is an auto-generated flat version of ConfigRootVolume.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatConfigRootVolume struct {
+	Type     *string `mapstructure:"type" cty:"type" hcl:"type"`
+	IOPS     *uint32 `mapstructure:"iops" cty:"iops" hcl:"iops"`
+	SizeInGB *uint64 `mapstructure:"size_in_gb" cty:"size_in_gb" hcl:"size_in_gb"`
+}
+
+// FlatMapstructure returns a new FlatConfigRootVolume.
+// FlatConfigRootVolume is an auto-generated flat version of ConfigRootVolume.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*ConfigRootVolume) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatConfigRootVolume)
+}
+
+// HCL2Spec returns the hcl spec of a ConfigRootVolume.
+// This spec is used by HCL to read the fields of ConfigRootVolume.
+// The decoded values from this spec will then be applied to a FlatConfigRootVolume.
+func (*FlatConfigRootVolume) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"type":       &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
+		"iops":       &hcldec.AttrSpec{Name: "iops", Type: cty.Number, Required: false},
+		"size_in_gb": &hcldec.AttrSpec{Name: "size_in_gb", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/scaleway/config_root_volume.go
+++ b/builder/scaleway/config_root_volume.go
@@ -1,0 +1,49 @@
+package scaleway
+
+import (
+	"fmt"
+
+	block "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+// IsConfigured returns true if root volume has been manually configured.
+// If true, the volume template should be used when creating the server.
+func (c *ConfigRootVolume) IsConfigured() bool {
+	return c.Type != "" || c.IOPS != nil || c.SizeInGB != 0
+}
+
+// VolumeServerTemplate returns the template to create the volume in a CreateServerRequest
+func (c *ConfigRootVolume) VolumeServerTemplate() *instance.VolumeServerTemplate {
+	tmpl := &instance.VolumeServerTemplate{}
+
+	if c.Type != "" {
+		tmpl.VolumeType = instance.VolumeVolumeType(c.Type)
+	} else {
+		tmpl.VolumeType = instance.VolumeVolumeTypeSbsVolume
+	}
+
+	if c.SizeInGB > 0 {
+		tmpl.Size = scw.SizePtr(scw.Size(c.SizeInGB) * scw.GB)
+	}
+
+	return tmpl
+}
+
+func (c *ConfigRootVolume) PostServerCreationSetup(blockAPI *block.API, server *instance.Server) error {
+	if c.IOPS != nil {
+		rootVolume, exists := server.Volumes["0"]
+		if !exists {
+			return fmt.Errorf("root Volume not found")
+		}
+		_, err := blockAPI.UpdateVolume(&block.UpdateVolumeRequest{
+			Zone:     rootVolume.Zone,
+			VolumeID: rootVolume.ID,
+			PerfIops: c.IOPS,
+		})
+		return err
+	}
+
+	return nil
+}

--- a/builder/scaleway/config_root_volume.go
+++ b/builder/scaleway/config_root_volume.go
@@ -1,7 +1,7 @@
 package scaleway
 
 import (
-	"fmt"
+	"errors"
 
 	block "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
@@ -35,7 +35,7 @@ func (c *ConfigRootVolume) PostServerCreationSetup(blockAPI *block.API, server *
 	if c.IOPS != nil {
 		rootVolume, exists := server.Volumes["0"]
 		if !exists {
-			return fmt.Errorf("root Volume not found")
+			return errors.New("root volume not found")
 		}
 		_, err := blockAPI.UpdateVolume(&block.UpdateVolumeRequest{
 			Zone:     rootVolume.Zone,

--- a/builder/scaleway/step_create_volume.go
+++ b/builder/scaleway/step_create_volume.go
@@ -118,12 +118,11 @@ func waitAndDeleteInstanceVolume(instanceAPI *instance.API, zone scw.Zone, volum
 	})
 	if err != nil && !httperrors.Is404(err) {
 		return err
-
 	}
 
 	err = instanceAPI.DeleteVolume(&instance.DeleteVolumeRequest{
 		VolumeID: volumeID,
-		Zone:     scw.Zone(zone),
+		Zone:     zone,
 	})
 	if err != nil {
 		return err

--- a/docs-partials/builder/scaleway/Config-not-required.mdx
+++ b/docs-partials/builder/scaleway/Config-not-required.mdx
@@ -23,6 +23,8 @@
 
 - `remove_volume` (bool) - RemoveVolume remove the temporary volumes created before running the server
 
+- `root_volume` (ConfigRootVolume) - RootVolumeType lets you configure the root volume
+
 - `block_volume` ([]ConfigBlockVolume) - BlockVolumes define block volumes attached to the server alongside the default volume
   See the [BlockVolumes](#block-volumes-configuration) documentation for fields.
 

--- a/docs-partials/builder/scaleway/ConfigRootVolume-not-required.mdx
+++ b/docs-partials/builder/scaleway/ConfigRootVolume-not-required.mdx
@@ -1,0 +1,9 @@
+<!-- Code generated from the comments of the ConfigRootVolume struct in builder/scaleway/config.go; DO NOT EDIT MANUALLY -->
+
+- `type` (string) - The type of the root volume
+
+- `iops` (\*uint32) - IOPS of the root volume if using SBS, will only affect runtime. Image's volumes cannot have a configured IOPS.
+
+- `size_in_gb` (uint64) - Size of the root volume
+
+<!-- End of code generated from the comments of the ConfigRootVolume struct in builder/scaleway/config.go; -->

--- a/internal/checks/block_snapshot.go
+++ b/internal/checks/block_snapshot.go
@@ -22,6 +22,7 @@ func (c *BlockSnapshotCheck) SizeInGB(size uint64) *BlockSnapshotCheck {
 
 	return c
 }
+
 func (c *BlockSnapshotCheck) Check(ctx context.Context) error {
 	testCtx := tester.ExtractCtx(ctx)
 	api := block.NewAPI(testCtx.ScwClient)

--- a/internal/checks/block_snapshot.go
+++ b/internal/checks/block_snapshot.go
@@ -1,0 +1,51 @@
+package checks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/scaleway/packer-plugin-scaleway/internal/tester"
+	block "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+type BlockSnapshotCheck struct {
+	zone       scw.Zone
+	snapshotID *string
+
+	size *scw.Size
+}
+
+func (c *BlockSnapshotCheck) SizeInGB(size uint64) *BlockSnapshotCheck {
+	c.size = scw.SizePtr(scw.Size(size) * scw.GB)
+
+	return c
+}
+func (c *BlockSnapshotCheck) Check(ctx context.Context) error {
+	testCtx := tester.ExtractCtx(ctx)
+	api := block.NewAPI(testCtx.ScwClient)
+
+	if c.snapshotID == nil {
+		return errors.New("snapshot ID is required")
+	}
+
+	snapshot, err := api.GetSnapshot(&block.GetSnapshotRequest{
+		Zone:       c.zone,
+		SnapshotID: *c.snapshotID,
+	})
+	if err != nil {
+		return fmt.Errorf("error getting snapshot %s: %w", *c.snapshotID, err)
+	}
+
+	if c.size != nil && snapshot.Size != *c.size {
+		return fmt.Errorf("snapshot size %d does not match expected size %d", snapshot.Size, *c.size)
+	}
+
+	return nil
+}
+
+// BlockSnapshot returns an empty check, to be passed to another check to fill ID and zone
+func BlockSnapshot() *BlockSnapshotCheck {
+	return &BlockSnapshotCheck{}
+}

--- a/internal/checks/volume.go
+++ b/internal/checks/volume.go
@@ -22,7 +22,8 @@ func (c *NoVolumesCheck) Check(ctx context.Context) error {
 	blockAPI := block.NewAPI(testCtx.ScwClient)
 
 	resp, err := instanceAPI.ListVolumes(&instance.ListVolumesRequest{
-		Zone: c.zone,
+		Zone:    c.zone,
+		Project: &testCtx.ProjectID,
 	}, scw.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to list instance volumes: %w", err)

--- a/internal/tests/block_test.go
+++ b/internal/tests/block_test.go
@@ -35,7 +35,7 @@ build {
 `,
 		Checks: []tester.PackerCheck{
 			checks.Image(zone, "packer-e2e-block").
-				RootVolumeType("b_ssd").
+				RootVolumeType("sbs_snapshot").
 				ExtraVolumeType("1", "sbs_snapshot"),
 			checks.NoVolume(zone),
 		},

--- a/internal/tests/root_volume_sbs_test.go
+++ b/internal/tests/root_volume_sbs_test.go
@@ -1,0 +1,42 @@
+package tests_test
+
+import (
+	"testing"
+
+	"github.com/scaleway/packer-plugin-scaleway/internal/checks"
+	"github.com/scaleway/packer-plugin-scaleway/internal/tester"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func TestRootVolumeSBS(t *testing.T) {
+	zone := scw.ZoneFrPar1
+
+	tester.Test(t, &tester.TestConfig{
+		Config: `
+source "scaleway" "basic" {
+  communicator = "none"
+  commercial_type = "PLAY2-PICO"
+  zone = "fr-par-1"
+  image = "ubuntu_jammy"
+  image_name = "packer-e2e-root-volume-sbs"
+  ssh_username = "root"
+  remove_volume = true
+
+  root_volume {
+    size_in_gb = 50
+    iops = 15000
+  }
+}
+
+build {
+  sources = ["source.scaleway.basic"]
+}
+`,
+		Checks: []tester.PackerCheck{
+			checks.Image(zone, "packer-e2e-root-volume-sbs").
+				RootVolumeType("sbs_snapshot").
+				RootVolumeBlockSnapshot(checks.BlockSnapshot().SizeInGB(50)),
+			checks.NoVolume(zone),
+		},
+	})
+}

--- a/internal/tests/root_volume_test.go
+++ b/internal/tests/root_volume_test.go
@@ -1,0 +1,42 @@
+package tests_test
+
+import (
+	"testing"
+
+	"github.com/scaleway/packer-plugin-scaleway/internal/checks"
+	"github.com/scaleway/packer-plugin-scaleway/internal/tester"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func TestRootVolume(t *testing.T) {
+	zone := scw.ZoneFrPar1
+
+	tester.Test(t, &tester.TestConfig{
+		Config: `
+source "scaleway" "basic" {
+  communicator = "none"
+  commercial_type = "PLAY2-PICO"
+  zone = "fr-par-1"
+  image = "ubuntu_jammy"
+  image_name = "packer-e2e-root-volume"
+  ssh_username = "root"
+  remove_volume = true
+
+  root_volume {
+    type = "b_ssd"
+    size_in_gb = 50
+  }
+}
+
+build {
+  sources = ["source.scaleway.basic"]
+}
+`,
+		Checks: []tester.PackerCheck{
+			checks.Image(zone, "packer-e2e-root-volume").
+				RootVolumeType("b_ssd").
+				SizeInGb(50),
+			checks.NoVolume(zone),
+		},
+	})
+}

--- a/internal/tests/simple_test.go
+++ b/internal/tests/simple_test.go
@@ -29,7 +29,7 @@ build {
 `,
 		Checks: []tester.PackerCheck{
 			checks.Image(zone, "packer-e2e-simple").
-				RootVolumeType("unified"),
+				RootVolumeType("sbs_snapshot"),
 			checks.NoVolume(zone),
 		},
 	})

--- a/internal/tests/testdata/block.cassette.yaml
+++ b/internal/tests/testdata/block.cassette.yaml
@@ -17,7 +17,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-block&page=1&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-block&page=1&project=b577a333-d52a-4d86-9310-b413d5fe9bb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -27,7 +27,7 @@ interactions:
         trailer: {}
         content_length: 720
         uncompressed: false
-        body: '{"images": [{"id": "b1902138-85b3-4de7-a502-d50f1e93c92f", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f7a0bcef-728b-4f5f-b0c2-45d859448169", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "13522482-24b6-4bca-93a1-0489e7e420b6", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:53:34.012424+00:00", "modification_date": "2025-02-07T13:53:34.012424+00:00", "default_bootscript": null, "from_server": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "37a6357e-f971-4fbf-a80d-1fc6b7cc328a", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "c9e1d66a-a330-4636-9419-b5f660df4d6e", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "1057e812-e695-43b1-be59-75d40c4433bd", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:36:41.434137+00:00", "modification_date": "2025-02-10T15:36:41.434137+00:00", "default_bootscript": null, "from_server": "c12a0843-fb85-4985-9441-2dc15014ed13", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
                 - "720"
@@ -36,9 +36,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:36 GMT
+                - Mon, 10 Feb 2025 15:36:44 GMT
             Link:
-                - </images?page=1&per_page=50&name=packer-e2e-block&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
+                - </images?page=1&per_page=50&name=packer-e2e-block&project=b577a333-d52a-4d86-9310-b413d5fe9bb1>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4909efc-166c-4ffb-a86d-1492cb331e18
+                - 3470787c-c644-4234-9b58-70dcaa8e776c
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 463.178792ms
+        duration: 384.537ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=b577a333-d52a-4d86-9310-b413d5fe9bb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,9 +89,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:36 GMT
+                - Mon, 10 Feb 2025 15:36:44 GMT
             Link:
-                - </volumes?page=0&per_page=100&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
+                - </volumes?page=0&per_page=100&project=b577a333-d52a-4d86-9310-b413d5fe9bb1>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2557dec-1c71-45f7-92ed-af4d51542ea3
+                - d41b6018-2520-4663-94b5-005fd9eece59
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 59.24775ms
+        duration: 66.034792ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=65a3940d-94a0-4a0b-932e-eedae2a6a98e
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=b577a333-d52a-4d86-9310-b413d5fe9bb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -142,7 +142,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:36 GMT
+                - Mon, 10 Feb 2025 15:36:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
@@ -152,7 +152,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0731cd11-8bff-4634-8c10-a9fb8adf1dfe
+                - cbf10e3f-5cb5-4de6-a599-c144fdee008d
         status: 200 OK
         code: 200
-        duration: 48.387125ms
+        duration: 54.641125ms

--- a/internal/tests/testdata/block.cassette.yaml
+++ b/internal/tests/testdata/block.cassette.yaml
@@ -17,7 +17,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-block&page=1&project=c2ca17f6-8d17-4179-b9ba-98b70afa882f
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-block&page=1&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
         method: GET
       response:
         proto: HTTP/2.0
@@ -27,7 +27,7 @@ interactions:
         trailer: {}
         content_length: 720
         uncompressed: false
-        body: '{"images": [{"id": "3bd77a2f-99b8-4649-b114-f685255d1564", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "root_volume": {"volume_type": "sbs_snapshot", "id": "7bf18661-8a2e-4a51-a1f7-2f4e59042901", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "a5d8fba7-332c-486f-b645-98f8f4aeacda", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T12:45:17.665043+00:00", "modification_date": "2025-02-07T12:45:17.665043+00:00", "default_bootscript": null, "from_server": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "b1902138-85b3-4de7-a502-d50f1e93c92f", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f7a0bcef-728b-4f5f-b0c2-45d859448169", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "13522482-24b6-4bca-93a1-0489e7e420b6", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:53:34.012424+00:00", "modification_date": "2025-02-07T13:53:34.012424+00:00", "default_bootscript": null, "from_server": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
                 - "720"
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:21 GMT
+                - Fri, 07 Feb 2025 13:53:36 GMT
             Link:
-                - </images?page=1&per_page=50&name=packer-e2e-block&project=c2ca17f6-8d17-4179-b9ba-98b70afa882f>; rel="last"
+                - </images?page=1&per_page=50&name=packer-e2e-block&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45a8e0a6-6265-424e-ba65-d90026e7cdcf
+                - d4909efc-166c-4ffb-a86d-1492cb331e18
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 537.406916ms
+        duration: 463.178792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=c2ca17f6-8d17-4179-b9ba-98b70afa882f
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:22 GMT
+                - Fri, 07 Feb 2025 13:53:36 GMT
             Link:
-                - </volumes?page=0&per_page=100&project=c2ca17f6-8d17-4179-b9ba-98b70afa882f>; rel="last"
+                - </volumes?page=0&per_page=100&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a3c6e77-8bb6-47a2-99e1-51752d125a2e
+                - c2557dec-1c71-45f7-92ed-af4d51542ea3
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 75.002875ms
+        duration: 59.24775ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=c2ca17f6-8d17-4179-b9ba-98b70afa882f
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=65a3940d-94a0-4a0b-932e-eedae2a6a98e
         method: GET
       response:
         proto: HTTP/2.0
@@ -142,9 +142,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:22 GMT
+                - Fri, 07 Feb 2025 13:53:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,7 +152,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a78d736f-78d6-4cd2-9bda-5a5fe3234dd9
+                - 0731cd11-8bff-4634-8c10-a9fb8adf1dfe
         status: 200 OK
         code: 200
-        duration: 45.906708ms
+        duration: 48.387125ms

--- a/internal/tests/testdata/block.cassette.yaml
+++ b/internal/tests/testdata/block.cassette.yaml
@@ -16,8 +16,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-block&page=1&project=3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-block&page=1&project=c2ca17f6-8d17-4179-b9ba-98b70afa882f
         method: GET
       response:
         proto: HTTP/2.0
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 720
         uncompressed: false
-        body: '{"images": [{"id": "967ca867-3164-41a4-98d2-5971c5901bcc", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "root_volume": {"id": "a8769235-13b3-4cdb-86fd-9d3757c14041", "name": "packer-e2e-block_snap_0", "volume_type": "b_ssd", "size": 10000000000}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "a193c5d7-d9f1-4c17-bf07-44f8a9c9553c", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-01-28T13:41:44.294450+00:00", "modification_date": "2025-01-28T13:41:44.294450+00:00", "default_bootscript": null, "from_server": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "3bd77a2f-99b8-4649-b114-f685255d1564", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "root_volume": {"volume_type": "sbs_snapshot", "id": "7bf18661-8a2e-4a51-a1f7-2f4e59042901", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "a5d8fba7-332c-486f-b645-98f8f4aeacda", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T12:45:17.665043+00:00", "modification_date": "2025-02-07T12:45:17.665043+00:00", "default_bootscript": null, "from_server": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
-                - "746"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:51 GMT
+                - Fri, 07 Feb 2025 12:45:21 GMT
             Link:
-                - </images?page=1&per_page=50&name=packer-e2e-block&project=3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10>; rel="last"
+                - </images?page=1&per_page=50&name=packer-e2e-block&project=c2ca17f6-8d17-4179-b9ba-98b70afa882f>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee90cc8c-6536-49aa-a12a-df912f1533f1
+                - 45a8e0a6-6265-424e-ba65-d90026e7cdcf
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 565.817542ms
+        duration: 537.406916ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=c2ca17f6-8d17-4179-b9ba-98b70afa882f
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:51 GMT
+                - Fri, 07 Feb 2025 12:45:22 GMT
             Link:
-                - </volumes?page=0&per_page=100&>; rel="last"
+                - </volumes?page=0&per_page=100&project=c2ca17f6-8d17-4179-b9ba-98b70afa882f>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 448a80b4-fbe2-4268-9e60-df743d2bd23f
+                - 3a3c6e77-8bb6-47a2-99e1-51752d125a2e
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 65.033792ms
+        duration: 75.002875ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=c2ca17f6-8d17-4179-b9ba-98b70afa882f
         method: GET
       response:
         proto: HTTP/2.0
@@ -142,9 +142,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:51 GMT
+                - Fri, 07 Feb 2025 12:45:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,7 +152,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f8c29b7-e140-4076-b10c-4ac7867d18c6
+                - a78d736f-78d6-4cd2-9bda-5a5fe3234dd9
         status: 200 OK
         code: 200
-        duration: 47.311541ms
+        duration: 45.906708ms

--- a/internal/tests/testdata/packer-e2e-block.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-block.cassette.yaml
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:20 GMT
+                - Fri, 07 Feb 2025 13:52:47 GMT
             Link:
                 - </images?page=0&per_page=50&name=packer-e2e-block>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bada823-6eb0-49bd-ae1e-ffd78fc9b754
+                - 531b3d29-8a25-4d6e-a377-5d928087dc08
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.081705833s
+        duration: 466.491959ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738932260&page=1
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738936367&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:21 GMT
+                - Fri, 07 Feb 2025 13:52:47 GMT
             Link:
-                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738932260>; rel="last"
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738936367>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26f5f9f1-55c3-4f0e-b9e2-2245c7a0bad4
+                - 50c6c363-e8c8-4c21-bc43-ca7cfab5206e
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 203.581417ms
+        duration: 179.780583ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"packer-e2e-block-vol1","perf_iops":5000,"project_id":"c2ca17f6-8d17-4179-b9ba-98b70afa882f","from_empty":{"size":20000000000},"tags":null}'
+        body: '{"name":"packer-e2e-block-vol1","perf_iops":5000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","from_empty":{"size":20000000000},"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -135,7 +135,7 @@ interactions:
         trailer: {}
         content_length: 404
         uncompressed: false
-        body: '{"id":"e5d0c685-b81f-4c04-ade6-a46057f6e0a9","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"c2ca17f6-8d17-4179-b9ba-98b70afa882f","created_at":"2025-02-07T12:44:23.151118Z","updated_at":"2025-02-07T12:44:23.151118Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+        body: '{"id":"ea106043-f4d3-477d-bc21-10f1a3267c28","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:52:49.776781Z","updated_at":"2025-02-07T13:52:49.776781Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "404"
@@ -144,9 +144,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:23 GMT
+                - Fri, 07 Feb 2025 13:52:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -154,10 +154,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 020dc1af-fff6-47e1-9121-02e3b41b949d
+                - f79e15da-9e6e-489a-a0be-c546df90be1c
         status: 200 OK
         code: 200
-        duration: 107.759041ms
+        duration: 153.889458ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -169,7 +169,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"packer-67a60024-75c1-ba3d-4032-ba230b835ab0","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","volumes":{"1":{"id":"e5d0c685-b81f-4c04-ade6-a46057f6e0a9","volume_type":"sbs_volume"}},"boot_type":"local","project":"c2ca17f6-8d17-4179-b9ba-98b70afa882f","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="]}'
+        body: '{"name":"packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","volumes":{"1":{"id":"ea106043-f4d3-477d-bc21-10f1a3267c28","volume_type":"sbs_volume"}},"boot_type":"local","project":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="]}'
         form: {}
         headers:
             Content-Type:
@@ -186,7 +186,7 @@ interactions:
         trailer: {}
         content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:23.629502+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:50.440382+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2579"
@@ -195,11 +195,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:24 GMT
+                - Fri, 07 Feb 2025 13:52:50 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -207,10 +207,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1cbbf243-c519-4fbf-b815-e87ce85e5e39
+                - bfc54d59-9dd8-47d3-ab2b-9b246ea50698
         status: 201 Created
         code: 201
-        duration: 1.103397917s
+        duration: 1.343603666s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -239,7 +239,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task": {"id": "5c89c27a-c876-4fd9-91c1-783846e603cd", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action", "href_result": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66", "started_at": "2025-02-07T12:44:24.487707+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "8b63ed58-5728-4f56-a49e-6d6b5d8b2fee", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action", "href_result": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d", "started_at": "2025-02-07T13:52:51.418602+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -248,11 +248,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:24 GMT
+                - Fri, 07 Feb 2025 13:52:50 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5c89c27a-c876-4fd9-91c1-783846e603cd
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/8b63ed58-5728-4f56-a49e-6d6b5d8b2fee
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -260,10 +260,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79e413d8-483d-4bd8-9e51-04d296dfba65
+                - bf096a69-12a4-45e2-beb4-1a523e9f94de
         status: 202 Accepted
         code: 202
-        duration: 304.529209ms
+        duration: 304.366292ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -280,7 +280,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -290,7 +290,7 @@ interactions:
         trailer: {}
         content_length: 2601
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:24.315557+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:51.212287+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2601"
@@ -299,9 +299,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:24 GMT
+                - Fri, 07 Feb 2025 13:52:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -309,10 +309,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0af1f397-53de-49bc-b32f-e1c50aab621d
+                - 6ca8db26-6690-4457-be82-4b2a4bfae87e
         status: 200 OK
         code: 200
-        duration: 147.658042ms
+        duration: 174.705583ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -329,7 +329,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         trailer: {}
         content_length: 3263
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}, "public_ips": [{"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:29.368988+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:55.813291+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "3263"
@@ -348,9 +348,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:29 GMT
+                - Fri, 07 Feb 2025 13:52:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -358,10 +358,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff046945-4eff-414c-8518-29143a5bd233
+                - 2dc50b08-2903-4dbf-ac37-564daa912c73
         status: 200 OK
         code: 200
-        duration: 143.64375ms
+        duration: 172.308209ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -378,7 +378,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -388,7 +388,7 @@ interactions:
         trailer: {}
         content_length: 3263
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}, "public_ips": [{"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:29.368988+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:55.813291+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "3263"
@@ -397,9 +397,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:29 GMT
+                - Fri, 07 Feb 2025 13:52:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -407,10 +407,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0145c64e-916d-4968-b08b-41e33209c72e
+                - 431544a9-a138-48ad-956e-f6c4e28422b5
         status: 200 OK
         code: 200
-        duration: 147.772041ms
+        duration: 475.678ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -429,7 +429,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -439,7 +439,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task": {"id": "c0301cb4-ed6b-482c-bab3-bd8869db2100", "description": "server_poweroff", "status": "pending", "href_from": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action", "href_result": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66", "started_at": "2025-02-07T12:44:30.457421+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "06263400-b55e-4b76-96ec-cd9b1493e38d", "description": "server_poweroff", "status": "pending", "href_from": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action", "href_result": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d", "started_at": "2025-02-07T13:52:57.567001+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -448,11 +448,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:30 GMT
+                - Fri, 07 Feb 2025 13:52:57 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c0301cb4-ed6b-482c-bab3-bd8869db2100
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/06263400-b55e-4b76-96ec-cd9b1493e38d
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -460,10 +460,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 70003f1a-5a41-4e53-aa17-9147af34abd6
+                - 3dc6efab-b626-4672-af5e-0f89c6fd6aea
         status: 202 Accepted
         code: 202
-        duration: 478.205791ms
+        duration: 300.375708ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -480,7 +480,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -490,7 +490,7 @@ interactions:
         trailer: {}
         content_length: 3223
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}, "public_ips": [{"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "3223"
@@ -499,9 +499,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:30 GMT
+                - Fri, 07 Feb 2025 13:52:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -509,10 +509,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c70124ba-fff1-44d3-b9b6-3dce15f3d93c
+                - aca848bb-a9e2-48d9-8412-d08e836bdca5
         status: 200 OK
         code: 200
-        duration: 208.178875ms
+        duration: 164.019833ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -529,7 +529,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         trailer: {}
         content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2695"
@@ -548,9 +548,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:35 GMT
+                - Fri, 07 Feb 2025 13:53:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -558,10 +558,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d94954c7-c486-4092-9b16-0d3ef7e32842
+                - 367b08d1-063f-417f-8b73-8722fc0b1a7b
         status: 200 OK
         code: 200
-        duration: 177.866959ms
+        duration: 157.310125ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -578,7 +578,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -588,7 +588,7 @@ interactions:
         trailer: {}
         content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2695"
@@ -597,9 +597,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:41 GMT
+                - Fri, 07 Feb 2025 13:53:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -607,10 +607,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4bd66b3-6ffa-46ee-9a72-afec0f7cc09d
+                - f667bbb0-6257-4381-951e-cbf57ac0eb17
         status: 200 OK
         code: 200
-        duration: 258.053459ms
+        duration: 194.940708ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -627,7 +627,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -637,7 +637,7 @@ interactions:
         trailer: {}
         content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2695"
@@ -646,9 +646,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:46 GMT
+                - Fri, 07 Feb 2025 13:53:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -656,10 +656,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85b9e5e5-31ae-40ad-8a48-8eef8251aa3b
+                - edb1d5be-512f-4ef8-84f7-2f5bf67c7d51
         status: 200 OK
         code: 200
-        duration: 161.307875ms
+        duration: 194.305416ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -676,7 +676,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -686,7 +686,7 @@ interactions:
         trailer: {}
         content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2695"
@@ -695,9 +695,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:51 GMT
+                - Fri, 07 Feb 2025 13:53:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -705,10 +705,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21e0a408-7374-440a-9e5a-d8189f5f4de4
+                - 03fceed1-1e48-4cb4-a0ce-cc0d1a1995d0
         status: 200 OK
         code: 200
-        duration: 170.297833ms
+        duration: 141.335625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -725,7 +725,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         trailer: {}
         content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2695"
@@ -744,9 +744,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:44:56 GMT
+                - Fri, 07 Feb 2025 13:53:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -754,10 +754,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40e3afa0-3869-451a-82bf-ce0fefd4e641
+                - d0beafff-789f-418e-91a0-7aca05316393
         status: 200 OK
         code: 200
-        duration: 330.160833ms
+        duration: 162.70525ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -774,7 +774,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -784,7 +784,7 @@ interactions:
         trailer: {}
         content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2695"
@@ -793,9 +793,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:02 GMT
+                - Fri, 07 Feb 2025 13:53:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,10 +803,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fa14859-c124-459a-a822-f82984c97ff0
+                - 13e4bec1-69a0-49b6-ad5f-f50660ce5757
         status: 200 OK
         code: 200
-        duration: 323.126084ms
+        duration: 188.6525ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -823,7 +823,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
         method: GET
       response:
         proto: HTTP/2.0
@@ -831,20 +831,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:53:30.866372+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:07 GMT
+                - Fri, 07 Feb 2025 13:53:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,48 +852,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9b19a3b-48e1-4796-9f16-a23a49db4ad8
+                - 0f33624d-949a-4f85-9ad0-57e725380e14
         status: 200 OK
         code: 200
-        duration: 167.743792ms
+        duration: 134.023375ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 141
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"action":"backup","name":"packer-e2e-block","volumes":{"bedc4584-bee2-4985-8a83-f5832ba7c022":{},"ea106043-f4d3-477d-bc21-10f1a3267c28":{}}}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
-        method: GET
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 351
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "3d041e81-1030-40b6-aae8-c887d6d2d04e", "description": "instance_backup", "status": "pending", "href_from": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action", "href_result": "/images/b1902138-85b3-4de7-a502-d50f1e93c92f", "started_at": "2025-02-07T13:53:34.628194+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "351"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:12 GMT
+                - Fri, 07 Feb 2025 13:53:34 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3d041e81-1030-40b6-aae8-c887d6d2d04e
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +905,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dd29754e-eb5e-435b-9feb-c71ccea24747
-        status: 200 OK
-        code: 200
-        duration: 135.730125ms
+                - b2a54859-34da-41b5-a807-f3a80c497d16
+        status: 202 Accepted
+        code: 202
+        duration: 665.943792ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -921,7 +925,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b1902138-85b3-4de7-a502-d50f1e93c92f
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,20 +933,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2579
+        content_length: 717
         uncompressed: false
-        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:45:13.405372+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"image": {"id": "b1902138-85b3-4de7-a502-d50f1e93c92f", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f7a0bcef-728b-4f5f-b0c2-45d859448169", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "13522482-24b6-4bca-93a1-0489e7e420b6", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:53:34.012424+00:00", "modification_date": "2025-02-07T13:53:34.012424+00:00", "default_bootscript": null, "from_server": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "state": "available", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2579"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:17 GMT
+                - Fri, 07 Feb 2025 13:53:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,52 +954,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b428199-db02-4633-8033-fdaa9e9cb2aa
+                - 1bb12eaa-6bd7-45c1-be1d-0e607a771921
         status: 200 OK
         code: 200
-        duration: 147.8535ms
+        duration: 83.829042ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 141
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"action":"backup","name":"packer-e2e-block","volumes":{"907ad7f0-5536-47bd-bde4-10ee70e36506":{},"e5d0c685-b81f-4c04-ade6-a46057f6e0a9":{}}}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action
-        method: POST
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 351
+        content_length: 0
         uncompressed: false
-        body: '{"task": {"id": "bba6e169-c53a-4a90-b4c2-741debd8dabe", "description": "instance_backup", "status": "pending", "href_from": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action", "href_result": "/images/3bd77a2f-99b8-4649-b114-f685255d1564", "started_at": "2025-02-07T12:45:18.685042+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "351"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:18 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/bba6e169-c53a-4a90-b4c2-741debd8dabe
+                - Fri, 07 Feb 2025 13:53:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1003,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 14058211-603d-435e-9a22-1f9f58eac054
-        status: 202 Accepted
-        code: 202
-        duration: 1.12466625s
+                - 1d117a9e-a518-4692-b375-7c17543cee88
+        status: 204 No Content
+        code: 204
+        duration: 576.832333ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1023,7 +1021,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/3bd77a2f-99b8-4649-b114-f685255d1564
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
         method: GET
       response:
         proto: HTTP/2.0
@@ -1031,20 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 717
+        content_length: 143
         uncompressed: false
-        body: '{"image": {"id": "3bd77a2f-99b8-4649-b114-f685255d1564", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "root_volume": {"volume_type": "sbs_snapshot", "id": "7bf18661-8a2e-4a51-a1f7-2f4e59042901", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "a5d8fba7-332c-486f-b645-98f8f4aeacda", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T12:45:17.665043+00:00", "modification_date": "2025-02-07T12:45:17.665043+00:00", "default_bootscript": null, "from_server": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "bedc4584-bee2-4985-8a83-f5832ba7c022"}'
         headers:
             Content-Length:
-                - "717"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:18 GMT
+                - Fri, 07 Feb 2025 13:53:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1052,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d5e2eee-c699-446e-a6c2-df7bfdb34a58
-        status: 200 OK
-        code: 200
-        duration: 97.710333ms
+                - c2369693-5b68-44e1-a3d9-2fbf35e6995f
+        status: 404 Not Found
+        code: 404
+        duration: 36.091167ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1072,7 +1070,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1080,18 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "bedc4584-bee2-4985-8a83-f5832ba7c022"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:18 GMT
+                - Fri, 07 Feb 2025 13:53:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 416eb5b6-d561-45bb-83cf-b1cf731bbec6
-        status: 204 No Content
-        code: 204
-        duration: 416.166625ms
+                - 21c5e708-7a63-4ba9-bc12-05832a87b346
+        status: 404 Not Found
+        code: 404
+        duration: 44.011041ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1119,28 +1119,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/907ad7f0-5536-47bd-bde4-10ee70e36506
-        method: DELETE
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 484
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "907ad7f0-5536-47bd-bde4-10ee70e36506"}'
+        body: '{"id":"bedc4584-bee2-4985-8a83-f5832ba7c022","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:52:50.580259Z","updated_at":"2025-02-07T13:53:35.250724Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:53:35.250724Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "484"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:19 GMT
+                - Fri, 07 Feb 2025 13:53:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7f27cdc-2fd7-4294-8d42-84e7b9e486f1
-        status: 404 Not Found
-        code: 404
-        duration: 39.404709ms
+                - 3fbb729b-8b64-41f8-a4a7-57fe8df9f504
+        status: 200 OK
+        code: 200
+        duration: 53.04525ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1168,7 +1168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/907ad7f0-5536-47bd-bde4-10ee70e36506
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1185,9 +1185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:19 GMT
+                - Fri, 07 Feb 2025 13:53:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1195,10 +1195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5990cf6a-3591-4ab5-8670-bf30242ddd8d
+                - 7b8abeac-14f5-4b68-acbb-c1f7f01cf538
         status: 204 No Content
         code: 204
-        duration: 180.386542ms
+        duration: 98.955709ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1215,8 +1215,8 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e5d0c685-b81f-4c04-ade6-a46057f6e0a9
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1225,7 +1225,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9"}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "ea106043-f4d3-477d-bc21-10f1a3267c28"}'
         headers:
             Content-Length:
                 - "143"
@@ -1234,9 +1234,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:19 GMT
+                - Fri, 07 Feb 2025 13:53:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1244,10 +1244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51738d25-4f14-43f4-b1d3-3871a4463fcb
+                - 7623f010-de4d-4998-97fa-1219785618cb
         status: 404 Not Found
         code: 404
-        duration: 47.565583ms
+        duration: 41.6365ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1264,7 +1264,105 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e5d0c685-b81f-4c04-ade6-a46057f6e0a9
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "ea106043-f4d3-477d-bc21-10f1a3267c28"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 82069e35-a6cb-42a8-9cb6-649cb32a8b4d
+        status: 404 Not Found
+        code: 404
+        duration: 34.999208ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 430
+        uncompressed: false
+        body: '{"id":"ea106043-f4d3-477d-bc21-10f1a3267c28","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:52:49.776781Z","updated_at":"2025-02-07T13:53:35.310712Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:53:35.310712Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "430"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 39c35dd9-c3ab-41ad-a224-5e6e2e90f91f
+        status: 200 OK
+        code: 200
+        duration: 61.622209ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1281,9 +1379,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 12:45:19 GMT
+                - Fri, 07 Feb 2025 13:53:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1291,7 +1389,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6711117b-a4eb-4699-ab97-fb06da61a135
+                - c173f352-d5f5-49d4-88d5-ca5acb59dbc8
         status: 204 No Content
         code: 204
-        duration: 96.039959ms
+        duration: 87.404291ms

--- a/internal/tests/testdata/packer-e2e-block.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-block.cassette.yaml
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:47 GMT
+                - Mon, 10 Feb 2025 15:35:51 GMT
             Link:
                 - </images?page=0&per_page=50&name=packer-e2e-block>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 531b3d29-8a25-4d6e-a377-5d928087dc08
+                - 51813ecc-43ec-4fa9-bea4-f811b5be009c
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 466.491959ms
+        duration: 367.040792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738936367&page=1
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1739201751&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:47 GMT
+                - Mon, 10 Feb 2025 15:35:51 GMT
             Link:
-                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738936367>; rel="last"
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1739201751>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50c6c363-e8c8-4c21-bc43-ca7cfab5206e
+                - 3be89f0f-de0b-4065-97a4-eb8dcaa61ed7
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 179.780583ms
+        duration: 175.760416ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"packer-e2e-block-vol1","perf_iops":5000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","from_empty":{"size":20000000000},"tags":null}'
+        body: '{"name":"packer-e2e-block-vol1","perf_iops":5000,"project_id":"b577a333-d52a-4d86-9310-b413d5fe9bb1","from_empty":{"size":20000000000},"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -135,7 +135,7 @@ interactions:
         trailer: {}
         content_length: 404
         uncompressed: false
-        body: '{"id":"ea106043-f4d3-477d-bc21-10f1a3267c28","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:52:49.776781Z","updated_at":"2025-02-07T13:52:49.776781Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+        body: '{"id":"530d0f22-79a8-4ee7-94cd-92aa46642c9d","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"b577a333-d52a-4d86-9310-b413d5fe9bb1","created_at":"2025-02-10T15:35:56.279368Z","updated_at":"2025-02-10T15:35:56.279368Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "404"
@@ -144,9 +144,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:49 GMT
+                - Mon, 10 Feb 2025 15:35:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -154,10 +154,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f79e15da-9e6e-489a-a0be-c546df90be1c
+                - 822f4045-b8fe-46cd-9aa3-f5480ce2b978
         status: 200 OK
         code: 200
-        duration: 153.889458ms
+        duration: 166.860875ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -169,7 +169,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","volumes":{"1":{"id":"ea106043-f4d3-477d-bc21-10f1a3267c28","volume_type":"sbs_volume"}},"boot_type":"local","project":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="]}'
+        body: '{"name":"packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","volumes":{"1":{"id":"530d0f22-79a8-4ee7-94cd-92aa46642c9d","volume_type":"sbs_volume"}},"boot_type":"local","project":"b577a333-d52a-4d86-9310-b413d5fe9bb1","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="]}'
         form: {}
         headers:
             Content-Type:
@@ -186,7 +186,7 @@ interactions:
         trailer: {}
         content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:50.440382+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:35:56.681054+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2579"
@@ -195,11 +195,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:50 GMT
+                - Mon, 10 Feb 2025 15:35:57 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -207,10 +207,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfc54d59-9dd8-47d3-ab2b-9b246ea50698
+                - db847a8f-7a59-4353-af00-093c8f0d4f92
         status: 201 Created
         code: 201
-        duration: 1.343603666s
+        duration: 1.323946917s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -239,7 +239,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task": {"id": "8b63ed58-5728-4f56-a49e-6d6b5d8b2fee", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action", "href_result": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d", "started_at": "2025-02-07T13:52:51.418602+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "3e92484b-9e12-4749-8ae5-1ef621e0479f", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/c12a0843-fb85-4985-9441-2dc15014ed13/action", "href_result": "/servers/c12a0843-fb85-4985-9441-2dc15014ed13", "started_at": "2025-02-10T15:35:58.127814+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -248,11 +248,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:50 GMT
+                - Mon, 10 Feb 2025 15:35:57 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/8b63ed58-5728-4f56-a49e-6d6b5d8b2fee
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3e92484b-9e12-4749-8ae5-1ef621e0479f
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -260,10 +260,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf096a69-12a4-45e2-beb4-1a523e9f94de
+                - d327f263-587a-443e-9b50-4766dea58907
         status: 202 Accepted
         code: 202
-        duration: 304.366292ms
+        duration: 505.100083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -280,7 +280,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -290,7 +290,7 @@ interactions:
         trailer: {}
         content_length: 2601
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:51.212287+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:35:57.839561+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2601"
@@ -299,9 +299,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:51 GMT
+                - Mon, 10 Feb 2025 15:35:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -309,10 +309,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ca8db26-6690-4457-be82-4b2a4bfae87e
+                - 04c1be38-c75c-4676-ba3d-cd5253f3c4ca
         status: 200 OK
         code: 200
-        duration: 174.705583ms
+        duration: 306.7935ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -329,7 +329,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -337,20 +337,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3263
+        content_length: 3258
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:55.813291+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9c8e941e-8283-4cc0-92ae-299a63dcb1dd"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9c8e941e-8283-4cc0-92ae-299a63dcb1dd"}], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:03.050411+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3263"
+                - "3258"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:56 GMT
+                - Mon, 10 Feb 2025 15:36:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -358,10 +358,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2dc50b08-2903-4dbf-ac37-564daa912c73
+                - a067f455-5510-42e0-a810-5492fcf61717
         status: 200 OK
         code: 200
-        duration: 172.308209ms
+        duration: 528.347083ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -378,7 +378,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -386,20 +386,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3263
+        content_length: 3258
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:55.813291+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9c8e941e-8283-4cc0-92ae-299a63dcb1dd"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9c8e941e-8283-4cc0-92ae-299a63dcb1dd"}], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:03.050411+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3263"
+                - "3258"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:56 GMT
+                - Mon, 10 Feb 2025 15:36:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -407,10 +407,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 431544a9-a138-48ad-956e-f6c4e28422b5
+                - fba0df8c-4b85-43ac-9255-4d641065569f
         status: 200 OK
         code: 200
-        duration: 475.678ms
+        duration: 304.512667ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -429,7 +429,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -439,7 +439,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task": {"id": "06263400-b55e-4b76-96ec-cd9b1493e38d", "description": "server_poweroff", "status": "pending", "href_from": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action", "href_result": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d", "started_at": "2025-02-07T13:52:57.567001+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "ec2ff12e-2a8e-438f-8b53-cb7c72542b4a", "description": "server_poweroff", "status": "pending", "href_from": "/servers/c12a0843-fb85-4985-9441-2dc15014ed13/action", "href_result": "/servers/c12a0843-fb85-4985-9441-2dc15014ed13", "started_at": "2025-02-10T15:36:04.620902+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -448,11 +448,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:57 GMT
+                - Mon, 10 Feb 2025 15:36:04 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/06263400-b55e-4b76-96ec-cd9b1493e38d
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ec2ff12e-2a8e-438f-8b53-cb7c72542b4a
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -460,10 +460,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3dc6efab-b626-4672-af5e-0f89c6fd6aea
+                - a805e2a6-78e6-4ea7-a136-df7891740840
         status: 202 Accepted
         code: 202
-        duration: 300.375708ms
+        duration: 407.946833ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -480,7 +480,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -488,20 +488,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3223
+        content_length: 3218
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "48dbd22c-899c-4512-b4d9-cd5b8d4ab260"}], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9c8e941e-8283-4cc0-92ae-299a63dcb1dd"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9c8e941e-8283-4cc0-92ae-299a63dcb1dd"}], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:04.411293+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3223"
+                - "3218"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:52:57 GMT
+                - Mon, 10 Feb 2025 15:36:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -509,10 +509,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aca848bb-a9e2-48d9-8412-d08e836bdca5
+                - 393a9944-ff5e-4426-a473-842823579a9a
         status: 200 OK
         code: 200
-        duration: 164.019833ms
+        duration: 303.872ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -529,7 +529,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -537,20 +537,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 2694
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:04.411293+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "2694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:02 GMT
+                - Mon, 10 Feb 2025 15:36:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -558,10 +558,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 367b08d1-063f-417f-8b73-8722fc0b1a7b
+                - d94755c9-8564-4d70-a38f-3ad4b418f19d
         status: 200 OK
         code: 200
-        duration: 157.310125ms
+        duration: 150.543916ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -578,7 +578,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -586,20 +586,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 2694
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:04.411293+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "2694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:07 GMT
+                - Mon, 10 Feb 2025 15:36:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -607,10 +607,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f667bbb0-6257-4381-951e-cbf57ac0eb17
+                - 27a3045e-93e5-4179-88e2-17dddadcd9dc
         status: 200 OK
         code: 200
-        duration: 194.940708ms
+        duration: 162.605208ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -627,7 +627,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -635,20 +635,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 2694
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:04.411293+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "2694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:13 GMT
+                - Mon, 10 Feb 2025 15:36:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -656,10 +656,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - edb1d5be-512f-4ef8-84f7-2f5bf67c7d51
+                - 83534265-b11d-4441-a4d6-bea2c98604ea
         status: 200 OK
         code: 200
-        duration: 194.305416ms
+        duration: 346.0205ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -676,7 +676,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -684,20 +684,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 2694
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:04.411293+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "2694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:18 GMT
+                - Mon, 10 Feb 2025 15:36:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -705,10 +705,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03fceed1-1e48-4cb4-a0ce-cc0d1a1995d0
+                - e024c7bc-b761-446c-bdae-aa97301e5034
         status: 200 OK
         code: 200
-        duration: 141.335625ms
+        duration: 183.577875ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -725,7 +725,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,20 +733,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 2694
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:04.411293+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "2694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:23 GMT
+                - Mon, 10 Feb 2025 15:36:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -754,10 +754,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d0beafff-789f-418e-91a0-7aca05316393
+                - 1c10a0ca-8d77-411e-9b2b-67f4b873570b
         status: 200 OK
         code: 200
-        duration: 162.70525ms
+        duration: 144.727708ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -774,7 +774,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -782,20 +782,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2695
+        content_length: 2694
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:52:57.362843+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "95", "hypervisor_id": "501", "node_id": "18"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:04.411293+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "101", "node_id": "4"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2695"
+                - "2694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:28 GMT
+                - Mon, 10 Feb 2025 15:36:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,10 +803,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13e4bec1-69a0-49b6-ad5f-f50660ce5757
+                - 535b035f-bcb0-42c3-9260-e3647be54474
         status: 200 OK
         code: 200
-        duration: 188.6525ms
+        duration: 141.9405ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -823,7 +823,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: GET
       response:
         proto: HTTP/2.0
@@ -833,7 +833,7 @@ interactions:
         trailer: {}
         content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "name": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a6102f-be5d-bedf-aa32-2de808a0cc3e", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "bedc4584-bee2-4985-8a83-f5832ba7c022", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea106043-f4d3-477d-bc21-10f1a3267c28", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCmyX1FU6yTCgQUXoFXk2ySy/TM6fMZAqi4IKZziPsNggK3xUqUJai4YoJWhZXuq/YMBosj+MNUNt6GEg74tpXTYfqEHvsWIwtON2u5nPDPmkqV47mEod2Pt8XiRwz4iSumm/sGXDeyBwD2qVy2AA29I+YdzO5J2R/b5CIxL79pVzgHZquBFf7h0aZBbiQsIsGytdfh8yq72G/4F8T7lpJhOk/Nt2CZrihkEg9uzSwAic5n2WSyFwTXwJSt130mwZTt421quKZ2FcApJOp5R9Cj3x3l8NsbLfmvpYt1r5mvaGRWbS9RO/XEq/nxmcFxTqYeV1aGiEi6K80i3CB4mZUe/Hu/A1vC/0sHNMazuWZ26xqKIG2nRuRy4iZK22dKrhM3waoqv240J9ol0vXs69lfmsk8HsXSXKrfLJTCIHX6DG88CTtiyfebmyGnVOMPoTw9TS9vLM5pJyZ+oLUygaZTRdxUK1rUytmOnjZk5Iv8odilYdUL2p16PloJv4Eb3sDbgvm1GQe8SADVOT+hGQaBNiFVTwQ32fAcSkkncq5v38i81K+xrX3Ws3UCADO2JERiRY7rmcJoMeUz06H+g0XIWGgCtNhpWrgo9E9K51rfa6Itw+zQXee8wnr0qBriSSO424zKscsPO0bQSGPDUVpmDmddQRt5haYllpU0/5pviw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:8b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:52:50.440382+00:00", "modification_date": "2025-02-07T13:53:30.866372+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "c12a0843-fb85-4985-9441-2dc15014ed13", "name": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1cd7-2661-f03d-6fe9-b3ebef43410b", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC2Yyyy1gDN4ixip/N7LGZ7Ghk87o2Cw0vRWmkqQ3mFYHMSHrZZwrZT6jI/Z3AMZsKXd3RfKnjbjA54Ggb1Qe36U3g0ht0HJ7mBsLQoFM3NDgaxnVnATm+fbU2sJNfyxKmyrNJjF5QM6YHHna1Eb6S4Dbh6qqtySbKrWiAvryTZqjS39EnBIuiSSOjkSBtlKNFnmd4xyRIyzwjPBRTDJahSxkLeiTGFGsFi/fhZ3U5n15JlRW+tQnOGrxJVvtrSqcTXegkDRKDoa1fbIT5GfdPQHrxzbPcJRgSX7FRHZ4uQSGllvLGH9pQthAc1JgY871ujjkMv3E+NSqZOHuhz5R78CndlwDM8R6f+qWQ0j+SlQ+qEIozMUHC0vTyhq6X2g4CDWwo1ANq7CyPN6g3kHCMr3NeE6nxIwLojBoYTp0YbzsdGsaykR7s1h0liBhFJ+NCq+694O6NZ98+SS6/poprd+lraSLdE9QgU28iBoJSMoITpSW9Uf4dxG16nmfO2UPr0WKlenM/+qN2YUHF+c93tgiiX0p3DW2hRaGWKtTfKi1j/KT1dchQRRAr0KQmjZO5pPviBJXBPCuPnhj8wQMkimaVIrbvqc3Zp9mjfPFPabMNiRoWVGTXKAs+OCuYilafNvEESslfl2gttnMEEXLitKvMenmOjbmG86qVtZtxbBQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:0d", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:35:56.681054+00:00", "modification_date": "2025-02-10T15:36:38.017211+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2579"
@@ -842,9 +842,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:33 GMT
+                - Mon, 10 Feb 2025 15:36:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,10 +852,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f33624d-949a-4f85-9ad0-57e725380e14
+                - 0085ebdc-19c5-4eb3-9aac-50ea0ca3cf5a
         status: 200 OK
         code: 200
-        duration: 134.023375ms
+        duration: 204.371959ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -867,14 +867,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"action":"backup","name":"packer-e2e-block","volumes":{"bedc4584-bee2-4985-8a83-f5832ba7c022":{},"ea106043-f4d3-477d-bc21-10f1a3267c28":{}}}'
+        body: '{"action":"backup","name":"packer-e2e-block","volumes":{"34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c":{},"530d0f22-79a8-4ee7-94cd-92aa46642c9d":{}}}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -884,7 +884,7 @@ interactions:
         trailer: {}
         content_length: 351
         uncompressed: false
-        body: '{"task": {"id": "3d041e81-1030-40b6-aae8-c887d6d2d04e", "description": "instance_backup", "status": "pending", "href_from": "/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d/action", "href_result": "/images/b1902138-85b3-4de7-a502-d50f1e93c92f", "started_at": "2025-02-07T13:53:34.628194+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "74dcc31f-41fb-462d-a377-fe69c691c458", "description": "instance_backup", "status": "pending", "href_from": "/servers/c12a0843-fb85-4985-9441-2dc15014ed13/action", "href_result": "/images/37a6357e-f971-4fbf-a80d-1fc6b7cc328a", "started_at": "2025-02-10T15:36:42.335841+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "351"
@@ -893,11 +893,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:34 GMT
+                - Mon, 10 Feb 2025 15:36:41 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3d041e81-1030-40b6-aae8-c887d6d2d04e
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/74dcc31f-41fb-462d-a377-fe69c691c458
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -905,10 +905,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2a54859-34da-41b5-a807-f3a80c497d16
+                - 429de2ba-7542-4946-b0fa-eca8fa044f56
         status: 202 Accepted
         code: 202
-        duration: 665.943792ms
+        duration: 1.020117334s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -925,7 +925,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b1902138-85b3-4de7-a502-d50f1e93c92f
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/37a6357e-f971-4fbf-a80d-1fc6b7cc328a
         method: GET
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         trailer: {}
         content_length: 717
         uncompressed: false
-        body: '{"image": {"id": "b1902138-85b3-4de7-a502-d50f1e93c92f", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f7a0bcef-728b-4f5f-b0c2-45d859448169", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "13522482-24b6-4bca-93a1-0489e7e420b6", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:53:34.012424+00:00", "modification_date": "2025-02-07T13:53:34.012424+00:00", "default_bootscript": null, "from_server": "6df5fd61-5b4d-4a70-877b-04a45c01d70d", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"image": {"id": "37a6357e-f971-4fbf-a80d-1fc6b7cc328a", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "c9e1d66a-a330-4636-9419-b5f660df4d6e", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "1057e812-e695-43b1-be59-75d40c4433bd", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:36:41.434137+00:00", "modification_date": "2025-02-10T15:36:41.434137+00:00", "default_bootscript": null, "from_server": "c12a0843-fb85-4985-9441-2dc15014ed13", "state": "available", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "717"
@@ -944,9 +944,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:34 GMT
+                - Mon, 10 Feb 2025 15:36:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -954,10 +954,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bb12eaa-6bd7-45c1-be1d-0e607a771921
+                - 12c5b779-f141-4b6a-9988-2f7ef9447fa2
         status: 200 OK
         code: 200
-        duration: 83.829042ms
+        duration: 88.89425ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -974,7 +974,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6df5fd61-5b4d-4a70-877b-04a45c01d70d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c12a0843-fb85-4985-9441-2dc15014ed13
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -991,9 +991,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d117a9e-a518-4692-b375-7c17543cee88
+                - bd756ec4-b26d-49c3-a030-e89c8b11fefb
         status: 204 No Content
         code: 204
-        duration: 576.832333ms
+        duration: 728.289458ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1021,7 +1021,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/530d0f22-79a8-4ee7-94cd-92aa46642c9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1031,7 +1031,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "bedc4584-bee2-4985-8a83-f5832ba7c022"}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d"}'
         headers:
             Content-Length:
                 - "143"
@@ -1040,9 +1040,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2369693-5b68-44e1-a3d9-2fbf35e6995f
+                - 1a274a4b-407c-4057-bd4f-267befa40870
         status: 404 Not Found
         code: 404
-        duration: 36.091167ms
+        duration: 31.479584ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1070,7 +1070,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/530d0f22-79a8-4ee7-94cd-92aa46642c9d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1080,7 +1080,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "bedc4584-bee2-4985-8a83-f5832ba7c022"}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "530d0f22-79a8-4ee7-94cd-92aa46642c9d"}'
         headers:
             Content-Length:
                 - "143"
@@ -1089,9 +1089,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:34 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21c5e708-7a63-4ba9-bc12-05832a87b346
+                - f97d5a3e-7874-48dd-b336-26f9a94b96b2
         status: 404 Not Found
         code: 404
-        duration: 44.011041ms
+        duration: 36.462083ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1119,7 +1119,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/530d0f22-79a8-4ee7-94cd-92aa46642c9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 484
+        content_length: 430
         uncompressed: false
-        body: '{"id":"bedc4584-bee2-4985-8a83-f5832ba7c022","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:52:50.580259Z","updated_at":"2025-02-07T13:53:35.250724Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:53:35.250724Z","zone":"fr-par-1"}'
+        body: '{"id":"530d0f22-79a8-4ee7-94cd-92aa46642c9d","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"b577a333-d52a-4d86-9310-b413d5fe9bb1","created_at":"2025-02-10T15:35:56.279368Z","updated_at":"2025-02-10T15:36:43.276018Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-10T15:36:43.276018Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "484"
+                - "430"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fbb729b-8b64-41f8-a4a7-57fe8df9f504
+                - 648100ec-5f28-4ff5-b3e2-688dd42f4ae1
         status: 200 OK
         code: 200
-        duration: 53.04525ms
+        duration: 48.550917ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1168,7 +1168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bedc4584-bee2-4985-8a83-f5832ba7c022
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/530d0f22-79a8-4ee7-94cd-92aa46642c9d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1185,9 +1185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1195,10 +1195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b8abeac-14f5-4b68-acbb-c1f7f01cf538
+                - 7c5233a4-1a78-4320-8c96-9f5bffff406f
         status: 204 No Content
         code: 204
-        duration: 98.955709ms
+        duration: 83.28975ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1215,7 +1215,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1225,7 +1225,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "ea106043-f4d3-477d-bc21-10f1a3267c28"}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c"}'
         headers:
             Content-Length:
                 - "143"
@@ -1234,9 +1234,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1244,10 +1244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7623f010-de4d-4998-97fa-1219785618cb
+                - d9dd7504-d7ff-4e43-b569-8d091b772887
         status: 404 Not Found
         code: 404
-        duration: 41.6365ms
+        duration: 32.958417ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1264,7 +1264,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1274,7 +1274,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "ea106043-f4d3-477d-bc21-10f1a3267c28"}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c"}'
         headers:
             Content-Length:
                 - "143"
@@ -1283,9 +1283,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1293,10 +1293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82069e35-a6cb-42a8-9cb6-649cb32a8b4d
+                - 120eb39f-8877-4dbe-8869-0bd651ba3356
         status: 404 Not Found
         code: 404
-        duration: 34.999208ms
+        duration: 52.103417ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1313,7 +1313,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1321,20 +1321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 430
+        content_length: 484
         uncompressed: false
-        body: '{"id":"ea106043-f4d3-477d-bc21-10f1a3267c28","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:52:49.776781Z","updated_at":"2025-02-07T13:53:35.310712Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:53:35.310712Z","zone":"fr-par-1"}'
+        body: '{"id":"34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"b577a333-d52a-4d86-9310-b413d5fe9bb1","created_at":"2025-02-10T15:35:56.831512Z","updated_at":"2025-02-10T15:36:43.193737Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-10T15:36:43.193737Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "430"
+                - "484"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1342,10 +1342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39c35dd9-c3ab-41ad-a224-5e6e2e90f91f
+                - 98c6a1a0-51a1-4972-9613-2736a284f71d
         status: 200 OK
         code: 200
-        duration: 61.622209ms
+        duration: 47.727125ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1362,7 +1362,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ea106043-f4d3-477d-bc21-10f1a3267c28
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/34b8befc-f3e2-47eb-8d5a-14a5a28bfb8c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1379,9 +1379,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:35 GMT
+                - Mon, 10 Feb 2025 15:36:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1389,7 +1389,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c173f352-d5f5-49d4-88d5-ca5acb59dbc8
+                - cf8702e8-b1ef-4ef0-ae23-a72ff52a379e
         status: 204 No Content
         code: 204
-        duration: 87.404291ms
+        duration: 68.381666ms

--- a/internal/tests/testdata/packer-e2e-block.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-block.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-block&page=1
         method: GET
       response:
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:38 GMT
+                - Fri, 07 Feb 2025 12:44:20 GMT
             Link:
                 - </images?page=0&per_page=50&name=packer-e2e-block>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bcd9fd1c-8131-4ff7-b67b-c69c9397fde1
+                - 6bada823-6eb0-49bd-ae1e-ffd78fc9b754
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 656.21775ms
+        duration: 1.081705833s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738071638&page=1
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738932260&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:38 GMT
+                - Fri, 07 Feb 2025 12:44:21 GMT
             Link:
-                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738071638>; rel="last"
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738932260>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3815cea8-747c-4652-9aca-ee09f124c5e5
+                - 26f5f9f1-55c3-4f0e-b9e2-2245c7a0bad4
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 187.925875ms
+        duration: 203.581417ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,13 +118,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"packer-e2e-block-vol1","perf_iops":5000,"project_id":"3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10","from_empty":{"size":20000000000},"tags":null}'
+        body: '{"name":"packer-e2e-block-vol1","perf_iops":5000,"project_id":"c2ca17f6-8d17-4179-b9ba-98b70afa882f","from_empty":{"size":20000000000},"tags":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
         url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
         method: POST
       response:
@@ -135,7 +135,7 @@ interactions:
         trailer: {}
         content_length: 404
         uncompressed: false
-        body: '{"id":"45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10","created_at":"2025-01-28T13:40:39.663029Z","updated_at":"2025-01-28T13:40:39.663029Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+        body: '{"id":"e5d0c685-b81f-4c04-ade6-a46057f6e0a9","name":"packer-e2e-block-vol1","type":"sbs_5k","size":20000000000,"project_id":"c2ca17f6-8d17-4179-b9ba-98b70afa882f","created_at":"2025-02-07T12:44:23.151118Z","updated_at":"2025-02-07T12:44:23.151118Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "404"
@@ -144,9 +144,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:39 GMT
+                - Fri, 07 Feb 2025 12:44:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -154,77 +154,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9dfcb570-f48b-4b51-823c-55b72fa9d24d
+                - 020dc1af-fff6-47e1-9121-02e3b41b949d
         status: 200 OK
         code: 200
-        duration: 120.754166ms
+        duration: 107.759041ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 1015
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=unknown_type&zone=fr-par-1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2402
-        uncompressed: false
-        body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_jammy","type":"instance_sbs"},{"id":"7044ae1e-a35d-4364-a962-93811c845f2f","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_sbs"}],"total_count":4}'
-        headers:
-            Content-Length:
-                - "2402"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 28 Jan 2025 13:40:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 16e7aa8d-7fe5-4cb4-b72e-b33b4a5f7d50
-        status: 200 OK
-        code: 200
-        duration: 87.56875ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 1039
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"packer-6798de56-240b-fae4-86d0-00d4b7691e9a","commercial_type":"PRO2-XXS","image":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","volumes":{"1":{"id":"45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04","volume_type":"sbs_volume"}},"boot_type":"local","project":"3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="]}'
+        body: '{"name":"packer-67a60024-75c1-ba3d-4032-ba230b835ab0","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","volumes":{"1":{"id":"e5d0c685-b81f-4c04-ade6-a46057f6e0a9","volume_type":"sbs_volume"}},"boot_type":"local","project":"c2ca17f6-8d17-4179-b9ba-98b70afa882f","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -233,22 +184,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3052
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:23.629502+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3052"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:40 GMT
+                - Fri, 07 Feb 2025 12:44:24 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -256,11 +207,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9d8c3b7-816c-472a-85e1-36c3b40af61d
+                - 1cbbf243-c519-4fbf-b815-e87ce85e5e39
         status: 201 Created
         code: 201
-        duration: 915.982959ms
-    - id: 5
+        duration: 1.103397917s
+    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -277,8 +228,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b/action
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -288,7 +239,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task": {"id": "78b74efb-cd5d-4794-afe9-c8676d82c9fd", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b/action", "href_result": "/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "started_at": "2025-01-28T13:40:41.231461+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "5c89c27a-c876-4fd9-91c1-783846e603cd", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action", "href_result": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66", "started_at": "2025-02-07T12:44:24.487707+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -297,11 +248,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:41 GMT
+                - Fri, 07 Feb 2025 12:44:24 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/78b74efb-cd5d-4794-afe9-c8676d82c9fd
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5c89c27a-c876-4fd9-91c1-783846e603cd
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -309,10 +260,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81d50ba2-83e7-4808-b2d8-2464a59bc805
+                - 79e413d8-483d-4bd8-9e51-04d296dfba65
         status: 202 Accepted
         code: 202
-        duration: 650.972958ms
+        duration: 304.529209ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2601
+        uncompressed: false
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:24.315557+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2601"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 12:44:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0af1f397-53de-49bc-b32f-e1c50aab621d
+        status: 200 OK
+        code: 200
+        duration: 147.658042ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -328,8 +328,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -337,20 +337,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3074
+        content_length: 3263
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.735601+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}, "public_ips": [{"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:29.368988+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3074"
+                - "3263"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:41 GMT
+                - Fri, 07 Feb 2025 12:44:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -358,10 +358,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8eb4efdf-c904-4f43-862c-2508ffab51af
+                - ff046945-4eff-414c-8518-29143a5bd233
         status: 200 OK
         code: 200
-        duration: 305.635208ms
+        duration: 143.64375ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -377,8 +377,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -386,20 +386,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3699
+        content_length: 3263
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}, "public_ips": [{"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.735601+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}, "public_ips": [{"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:29.368988+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3699"
+                - "3263"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:46 GMT
+                - Fri, 07 Feb 2025 12:44:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -407,158 +407,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b378592f-8412-49d5-ac26-449b1cdc08e7
+                - 0145c64e-916d-4968-b08b-41e33209c72e
         status: 200 OK
         code: 200
-        duration: 190.582917ms
+        duration: 147.772041ms
     - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3699
-        uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}, "public_ips": [{"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.735601+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3699"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 28 Jan 2025 13:40:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 69faaf75-4731-4211-986b-94f1b7520c4e
-        status: 200 OK
-        code: 200
-        duration: 141.874125ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3730
-        uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}, "public_ips": [{"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:55.169412+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3730"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 28 Jan 2025 13:40:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2baee4df-9c9e-4a5b-a56f-eb7b87353ffd
-        status: 200 OK
-        code: 200
-        duration: 133.003625ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3730
-        uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}, "public_ips": [{"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:55.169412+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3730"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 28 Jan 2025 13:40:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0cd40133-e209-4963-9f90-bb49f59e64f7
-        status: 200 OK
-        code: 200
-        duration: 125.789583ms
-    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -575,8 +428,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b/action
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -586,7 +439,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task": {"id": "1f9b8c21-4bb4-42c6-a178-4988950402f5", "description": "server_poweroff", "status": "pending", "href_from": "/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b/action", "href_result": "/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "started_at": "2025-01-28T13:40:57.448973+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "c0301cb4-ed6b-482c-bab3-bd8869db2100", "description": "server_poweroff", "status": "pending", "href_from": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action", "href_result": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66", "started_at": "2025-02-07T12:44:30.457421+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -595,11 +448,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:57 GMT
+                - Fri, 07 Feb 2025 12:44:30 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1f9b8c21-4bb4-42c6-a178-4988950402f5
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c0301cb4-ed6b-482c-bab3-bd8869db2100
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -607,10 +460,157 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 728195b8-b97e-42c6-b7d3-561f009f07e8
+                - 70003f1a-5a41-4e53-aa17-9147af34abd6
         status: 202 Accepted
         code: 202
-        duration: 373.523709ms
+        duration: 478.205791ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3223
+        uncompressed: false
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}, "public_ips": [{"id": "b7384ad9-8dc7-4920-9b9f-24efe98451fb", "address": "163.172.143.108", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "38912130-b338-491e-8b43-59f7295d7fb9"}], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3223"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 12:44:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c70124ba-fff1-44d3-b9b6-3dce15f3d93c
+        status: 200 OK
+        code: 200
+        duration: 208.178875ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2695
+        uncompressed: false
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2695"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 12:44:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d94954c7-c486-4092-9b16-0d3ef7e32842
+        status: 200 OK
+        code: 200
+        duration: 177.866959ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2695
+        uncompressed: false
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2695"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 12:44:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e4bd66b3-6ffa-46ee-9a72-afec0f7cc09d
+        status: 200 OK
+        code: 200
+        duration: 258.053459ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -626,8 +626,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -635,20 +635,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3690
+        content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}, "public_ips": [{"id": "6190b01e-20f4-41b1-8e7d-2f3f09e84cb1", "address": "51.15.201.39", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a9feffc6-0211-4087-8238-90a96cae3768"}], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3690"
+                - "2695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:40:57 GMT
+                - Fri, 07 Feb 2025 12:44:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -656,10 +656,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c56fb6c-21d7-4416-a579-ec3386660aaa
+                - 85b9e5e5-31ae-40ad-8a48-8eef8251aa3b
         status: 200 OK
         code: 200
-        duration: 196.590167ms
+        duration: 161.307875ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -675,8 +675,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -684,20 +684,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "2695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:02 GMT
+                - Fri, 07 Feb 2025 12:44:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -705,10 +705,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f920004-cb87-42f7-bf64-ceef29162e1e
+                - 21e0a408-7374-440a-9e5a-d8189f5f4de4
         status: 200 OK
         code: 200
-        duration: 154.781667ms
+        duration: 170.297833ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -724,8 +724,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,20 +733,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "2695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:07 GMT
+                - Fri, 07 Feb 2025 12:44:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -754,10 +754,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25d97ce1-0e20-4c9d-b951-7b3b6c4ca135
+                - 40e3afa0-3869-451a-82bf-ce0fefd4e641
         status: 200 OK
         code: 200
-        duration: 149.931584ms
+        duration: 330.160833ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -773,8 +773,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -782,20 +782,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "2695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:12 GMT
+                - Fri, 07 Feb 2025 12:45:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,10 +803,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b26bfe30-d9d5-4226-b988-a6142200d3fe
+                - 3fa14859-c124-459a-a822-f82984c97ff0
         status: 200 OK
         code: 200
-        duration: 158.07225ms
+        duration: 323.126084ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -822,8 +822,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -831,20 +831,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "2695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:18 GMT
+                - Fri, 07 Feb 2025 12:45:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,10 +852,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 115d4fa2-ca63-4716-aa8c-41632466044f
+                - e9b19a3b-48e1-4796-9f16-a23a49db4ad8
         status: 200 OK
         code: 200
-        duration: 221.395125ms
+        duration: 167.743792ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -871,8 +871,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,20 +880,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 2695
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:44:30.084219+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "58", "hypervisor_id": "1001", "node_id": "9"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "2695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:23 GMT
+                - Fri, 07 Feb 2025 12:45:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +901,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc481e48-ccf3-444f-9ba0-6ebe876ec6de
+                - dd29754e-eb5e-435b-9feb-c71ccea24747
         status: 200 OK
         code: 200
-        duration: 150.881ms
+        duration: 135.730125ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -920,8 +920,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,20 +929,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "name": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "hostname": "packer-67a60024-75c1-ba3d-4032-ba230b835ab0", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "907ad7f0-5536-47bd-bde4-10ee70e36506", "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDEazZBnTwhR0+jRgXRgyb3M2vP9vSYWSgPPceuSjEUb74/Px8Q4J6q0p1FLjOOGQndI5HfVsB/kt/K03c0RkLttjJ/lNokrnjrJFhlL2Hgu/snbO5Sgm2HV7V2YfgpflVv+fey+zqYbqUzftqOFU5hPve+K5hP2maFdr6InPUCZzH+TPqCs2w3IqE7ZnStbphD2Apbgu+1TsOP4GnPIidL9zlMWzMcjWIiENpEig2nNtY0zTfLyT6AXhMDBYZMXUbZFLN59xxODw4hL7Y2OLJ4ps9y6Gar/FE+PZGB+zg02IxOi1sDJUZt5SKsi4kJnrBLmd8F3lkSUOOdvMDTDgnwt3/f7qDbGWeU2TtAJPiU5YNI3bBgip43FkfQad5PQNoXSUGQv3WycN4/TtKkR5km8Blz0Acdcdv7rmYzCB/RaFcpBgmWzydk71omBmD37EGr0itpiYNdL1DTLN+A01nIu0kjlVypnRjZ05ZkIf0Gfy5QT7Ivpcw418PU1M7OJubXEEQkeaBeZb05xlGbjokcz4cplwfAs1YZ6UjiV2F2MijxNaBJwkiAC4MNL4ppQq6QM6neXVwDwzjr1okPA8RdYcRd9j51Qar0SF3l4Naexm4bg3TecMksN+oHKud9K4oRXujT+lC0uV76dd+hSfayfJU+qsxteKqYnuD9pO0CFQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9a:2b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T12:44:23.629502+00:00", "modification_date": "2025-02-07T12:45:13.405372+00:00", "bootscript": null, "security_group": {"id": "3b079218-4b48-4894-808e-063abf8848ed", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:28 GMT
+                - Fri, 07 Feb 2025 12:45:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,48 +950,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31a48d8d-6b93-4cb0-9f58-2f2a6d1ac68a
+                - 9b428199-db02-4633-8033-fdaa9e9cb2aa
         status: 200 OK
         code: 200
-        duration: 148.76725ms
+        duration: 147.8535ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 141
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"action":"backup","name":"packer-e2e-block","volumes":{"907ad7f0-5536-47bd-bde4-10ee70e36506":{},"e5d0c685-b81f-4c04-ade6-a46057f6e0a9":{}}}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 351
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "bba6e169-c53a-4a90-b4c2-741debd8dabe", "description": "instance_backup", "status": "pending", "href_from": "/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66/action", "href_result": "/images/3bd77a2f-99b8-4649-b114-f685255d1564", "started_at": "2025-02-07T12:45:18.685042+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "351"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:33 GMT
+                - Fri, 07 Feb 2025 12:45:18 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/bba6e169-c53a-4a90-b4c2-741debd8dabe
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +1003,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13f9592e-fbb3-4386-b8de-be85d933de13
-        status: 200 OK
-        code: 200
-        duration: 143.300584ms
+                - 14058211-603d-435e-9a22-1f9f58eac054
+        status: 202 Accepted
+        code: 202
+        duration: 1.12466625s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1018,8 +1022,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/3bd77a2f-99b8-4649-b114-f685255d1564
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,20 +1031,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3168
+        content_length: 717
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:57.294817+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "28", "hypervisor_id": "801", "node_id": "28"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"image": {"id": "3bd77a2f-99b8-4649-b114-f685255d1564", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "c2ca17f6-8d17-4179-b9ba-98b70afa882f", "root_volume": {"volume_type": "sbs_snapshot", "id": "7bf18661-8a2e-4a51-a1f7-2f4e59042901", "size": 0, "name": ""}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "a5d8fba7-332c-486f-b645-98f8f4aeacda", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T12:45:17.665043+00:00", "modification_date": "2025-02-07T12:45:17.665043+00:00", "default_bootscript": null, "from_server": "fd1fb5a8-6840-4730-a2e1-274308d7ba66", "state": "available", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3168"
+                - "717"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:39 GMT
+                - Fri, 07 Feb 2025 12:45:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1052,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3daf1250-b67b-40b5-8022-a6cf0352c8b8
+                - 4d5e2eee-c699-446e-a6c2-df7bfdb34a58
         status: 200 OK
         code: 200
-        duration: 135.158625ms
+        duration: 97.710333ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1067,29 +1071,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fd1fb5a8-6840-4730-a2e1-274308d7ba66
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3052
+        content_length: 0
         uncompressed: false
-        body: '{"server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "hostname": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "server": {"id": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "name": "packer-6798de56-240b-fae4-86d0-00d4b7691e9a"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:40:40.196323+00:00", "tags": [], "zone": "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1RCRGm04uk5jgq/w19AWbtO6ZxmVWDP1bv7LpEJioU2wV8G5MzoXAOkUTzbRATdUENobrVPMMayxqltPI6tDBd8I6DoAZAyd7WDcAM3l+uzopToQHlaQQS1kMGR5rDQbaj0WUwxLXKmZmJcYfOEvri0llIfCayLMofdKPNN8tAPQBv6UK5WiLjrH7PSw5l08yGK+ze0NxxTHqDx/4UUSOGOxAqoL6cmQhArQLzZTz5Houm5RkrtFNurhAp/2N9nFSSL3z96BgVeuCwkAWf5NkL8hFltvLHqgIbmI/gbdBtzoGZB9af8FoGYLK3z/dCUmhZ8OwJ1vmSJpdbyuOG0+2LhCpihPzcbIDfvVNhFZNs0D1MHJuaYhzXukh3g6OuomSmg/4EhCqExNA/wsUABO5tfMx5//EHDhU/z8AanzAAvqer/dSTaw6nCtozp7fONRw4xR+hAb3tysauwen1u0/BYEZj+WO5kxCHxRN6M0qMXxTGhzvr520TAST2AEj5UCwWjY2vW/aPOR35xQaR0ovnHmyfs32e5BxuKpcjdlZXfoS8ZgMXN5X2uu/qGgj01e9+a44JmJCY1cyL6AAt36jDhlHBzcBWdVDs2dKthkuVwTYH7BNVP1a47Mgxq8/Qt92jmrkl30cb6YWktdDga50u6mxGJnECHgQJRyNMIPbYQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:45:d3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-28T13:40:40.196323+00:00", "modification_date": "2025-01-28T13:41:40.297053+00:00", "bootscript": null, "security_group": {"id": "2c4f1a72-b9ee-4d14-9bbd-dd5c04e83eaa", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "3052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:43 GMT
+                - Fri, 07 Feb 2025 12:45:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1097,52 +1099,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c13e4a63-8e7d-4efa-9b8f-663309d25f82
-        status: 200 OK
-        code: 200
-        duration: 138.146292ms
+                - 416eb5b6-d561-45bb-83cf-b1cf731bbec6
+        status: 204 No Content
+        code: 204
+        duration: 416.166625ms
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 141
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"action":"backup","name":"packer-e2e-block","volumes":{"45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04":{},"d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff":{}}}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b/action
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/907ad7f0-5536-47bd-bde4-10ee70e36506
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 351
+        content_length: 143
         uncompressed: false
-        body: '{"task": {"id": "23b2b100-1690-4100-8ffb-03d1e8f3d53b", "description": "instance_backup", "status": "pending", "href_from": "/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b/action", "href_result": "/images/967ca867-3164-41a4-98d2-5971c5901bcc", "started_at": "2025-01-28T13:41:44.789700+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "907ad7f0-5536-47bd-bde4-10ee70e36506"}'
         headers:
             Content-Length:
-                - "351"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:44 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/23b2b100-1690-4100-8ffb-03d1e8f3d53b
+                - Fri, 07 Feb 2025 12:45:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1150,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47b3df89-3c38-447a-b558-1705fb2d39a0
-        status: 202 Accepted
-        code: 202
-        duration: 550.103542ms
+                - f7f27cdc-2fd7-4294-8d42-84e7b9e486f1
+        status: 404 Not Found
+        code: 404
+        duration: 39.404709ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1169,29 +1167,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/967ca867-3164-41a4-98d2-5971c5901bcc
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/907ad7f0-5536-47bd-bde4-10ee70e36506
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 742
+        content_length: 0
         uncompressed: false
-        body: '{"image": {"id": "967ca867-3164-41a4-98d2-5971c5901bcc", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "root_volume": {"id": "a8769235-13b3-4cdb-86fd-9d3757c14041", "name": "packer-e2e-block_snap_0", "volume_type": "b_ssd", "size": 10000000000}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "a193c5d7-d9f1-4c17-bf07-44f8a9c9553c", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-01-28T13:41:44.294450+00:00", "modification_date": "2025-01-28T13:41:44.294450+00:00", "default_bootscript": null, "from_server": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "state": "creating", "tags": [], "zone": "fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "742"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:44 GMT
+                - Fri, 07 Feb 2025 12:45:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1199,10 +1195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f2dd719-2496-448b-971b-951bd9c6d5af
-        status: 200 OK
-        code: 200
-        duration: 91.613542ms
+                - 5990cf6a-3591-4ab5-8670-bf30242ddd8d
+        status: 204 No Content
+        code: 204
+        duration: 180.386542ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1218,29 +1214,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/967ca867-3164-41a4-98d2-5971c5901bcc
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e5d0c685-b81f-4c04-ade6-a46057f6e0a9
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 743
+        content_length: 143
         uncompressed: false
-        body: '{"image": {"id": "967ca867-3164-41a4-98d2-5971c5901bcc", "name": "packer-e2e-block", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "3df5fc53-1c2c-49d6-bcb2-87b2bf0d6c10", "root_volume": {"id": "a8769235-13b3-4cdb-86fd-9d3757c14041", "name": "packer-e2e-block_snap_0", "volume_type": "b_ssd", "size": 10000000000}, "extra_volumes": {"1": {"volume_type": "sbs_snapshot", "id": "a193c5d7-d9f1-4c17-bf07-44f8a9c9553c", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-01-28T13:41:44.294450+00:00", "modification_date": "2025-01-28T13:41:44.294450+00:00", "default_bootscript": null, "from_server": "c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "e5d0c685-b81f-4c04-ade6-a46057f6e0a9"}'
         headers:
             Content-Length:
-                - "743"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:49 GMT
+                - Fri, 07 Feb 2025 12:45:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,10 +1244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a051ade-a928-4a71-90dd-16fc79575373
-        status: 200 OK
-        code: 200
-        duration: 106.972833ms
+                - 51738d25-4f14-43f4-b1d3-3871a4463fcb
+        status: 404 Not Found
+        code: 404
+        duration: 47.565583ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1267,8 +1263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c5a1dbf7-5db6-4ad7-83b6-a98cc93c1f5b
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e5d0c685-b81f-4c04-ade6-a46057f6e0a9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1285,9 +1281,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 28 Jan 2025 13:41:49 GMT
+                - Fri, 07 Feb 2025 12:45:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1295,150 +1291,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34483122-88a5-4bca-a4c4-1a54fa6f8e30
+                - 6711117b-a4eb-4699-ab97-fb06da61a135
         status: 204 No Content
         code: 204
-        duration: 355.7375ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3b78c5f-fd7b-46cd-8a8f-192147c2a5ff
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 28 Jan 2025 13:41:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b19000ec-31c3-4f66-a226-532f602de0b1
-        status: 204 No Content
-        code: 204
-        duration: 168.587083ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 28 Jan 2025 13:41:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 46e431e5-ddda-4cab-945e-a8372db0f3e1
-        status: 404 Not Found
-        code: 404
-        duration: 45.755125ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/45f0fdaa-9e88-4ae6-8a58-8b4eb0d36d04
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 28 Jan 2025 13:41:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e075ce72-6f7b-4e1d-b1f7-f4163045a99f
-        status: 204 No Content
-        code: 204
-        duration: 96.143ms
+        duration: 96.039959ms

--- a/internal/tests/testdata/packer-e2e-root-volume-sbs.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-root-volume-sbs.cassette.yaml
@@ -1,0 +1,1201 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-root-volume-sbs&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"images": []}'
+        headers:
+            Content-Length:
+                - "14"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:45 GMT
+            Link:
+                - </images?page=0&per_page=50&name=packer-e2e-root-volume-sbs>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 019e8c6c-760e-46b5-86df-13800299d55e
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 516.266667ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1739201805&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"snapshots": []}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:45 GMT
+            Link:
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1739201805>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c512391c-ba95-41b3-963c-6b92dd5a6529
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 193.996333ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 992
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43","commercial_type":"PLAY2-PICO","image":"ubuntu_jammy","volumes":{"0":{"size":50000000000,"volume_type":"sbs_volume"}},"boot_type":"local","project":"b577a333-d52a-4d86-9310-b413d5fe9bb1","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2464
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:46.717460+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:46 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 977518a0-f37b-4010-a1cf-01d524c31012
+        status: 201 Created
+        code: 201
+        duration: 983.651834ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 19
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"perf_iops":15000}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c9584eaf-b206-4456-99fd-9853c8f7b8b7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 688
+        uncompressed: false
+        body: '{"id":"c9584eaf-b206-4456-99fd-9853c8f7b8b7","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":50000000000,"project_id":"b577a333-d52a-4d86-9310-b413d5fe9bb1","created_at":"2025-02-10T15:36:46.854944Z","updated_at":"2025-02-10T15:36:46.854944Z","references":[{"id":"f24099d5-1909-4702-a452-5627df6bf471","product_resource_type":"instance_server","product_resource_id":"8122c68c-01b5-46b9-8201-aefe8c91fa98","created_at":"2025-02-10T15:36:46.854944Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"updating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "688"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bd9d20d5-a86c-4a9e-91ec-8ea4d2720bb4
+        status: 200 OK
+        code: 200
+        duration: 122.810083ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 20
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"poweron"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 357
+        uncompressed: false
+        body: '{"task": {"id": "3e4b6c24-e125-4180-8cd6-05743f49fd09", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98/action", "href_result": "/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98", "started_at": "2025-02-10T15:36:47.610807+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "357"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:47 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3e4b6c24-e125-4180-8cd6-05743f49fd09
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8aef0e56-d378-434d-a0bc-2c13973c693f
+        status: 202 Accepted
+        code: 202
+        duration: 383.023959ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2486
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:47.405616+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2486"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c883f627-0b8d-4ced-9bf4-fe4449daa803
+        status: 200 OK
+        code: 200
+        duration: 201.663291ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3144
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "f31f2ead-9f72-466c-94c8-0dc86e71c200"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "f31f2ead-9f72-466c-94c8-0dc86e71c200"}], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:50.828049+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3144"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c1af7c0e-34b4-4df3-a56f-8a8854ed9515
+        status: 200 OK
+        code: 200
+        duration: 167.6095ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3144
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "f31f2ead-9f72-466c-94c8-0dc86e71c200"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "f31f2ead-9f72-466c-94c8-0dc86e71c200"}], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:50.828049+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3144"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 33e11819-d656-47ba-bdb1-57c6005b45ba
+        status: 200 OK
+        code: 200
+        duration: 257.587459ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 21
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"poweroff"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 352
+        uncompressed: false
+        body: '{"task": {"id": "51ef83ae-046d-4fd2-965c-1de01cac9016", "description": "server_poweroff", "status": "pending", "href_from": "/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98/action", "href_result": "/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98", "started_at": "2025-02-10T15:36:53.569704+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "352"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:53 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/51ef83ae-046d-4fd2-965c-1de01cac9016
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f387ad39-bc62-49c3-b2b2-dec3789b7aaa
+        status: 202 Accepted
+        code: 202
+        duration: 305.262333ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3104
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "f31f2ead-9f72-466c-94c8-0dc86e71c200"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "f31f2ead-9f72-466c-94c8-0dc86e71c200"}], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:53.425416+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3104"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 55d4f1ae-0258-48ec-a302-afb16735a50e
+        status: 200 OK
+        code: 200
+        duration: 310.232042ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2580
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:53.425416+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:36:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5877f6eb-7a19-4d59-9f5b-11aa048a1cf8
+        status: 200 OK
+        code: 200
+        duration: 216.679584ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2580
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:53.425416+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dad21c17-35d3-4212-8a67-ae5744264205
+        status: 200 OK
+        code: 200
+        duration: 425.960459ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2580
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:53.425416+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6c068900-a8ac-40ec-8d8e-b6ae355caa09
+        status: 200 OK
+        code: 200
+        duration: 605.787625ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2580
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:53.425416+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 20476f32-68f2-4743-bd56-77a33610211e
+        status: 200 OK
+        code: 200
+        duration: 162.547042ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2580
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:53.425416+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0ba76942-9e89-4bb5-9b91-722d73337d1b
+        status: 200 OK
+        code: 200
+        duration: 322.526833ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2580
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:36:53.425416+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "30", "hypervisor_id": "101", "node_id": "29"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 393c60e8-779d-49fd-9bc4-4f09f0c25ef2
+        status: 200 OK
+        code: 200
+        duration: 180.736542ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2464
+        uncompressed: false
+        body: '{"server": {"id": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "name": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d0d-a359-1d5b-3ca1-00b9eb61da43", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDvBzaAZfrDUdVkjZ7bBVJ2cJI/KRMPPsG511mSGK4zbmLa55mcSdgqiU75rOH3ppRAx7s++j9yNbfXDZMIg2L52WNcmPHIcMQN3sUH90qHNCMaLnEKFqqD3tJ68X0gf20TwNZsqWj7tLePJjGupoOxeVsLxjA+KqiEWDBUIcGOi8hDLmgnixQh2YsGHr/A+ohqGmQCZwuieqvYLZCIRSHiKJ4DLCJLe2Dvrdb8uvACFy5NSuvp8aVw37KrMjdX2zY2M4agZfmEVk7PBaKXxtVueuLvSVrkv9uk2Td/GbJtv3aaJyITwU1BsHEq0f5cFWx2wwFJgGiU7q7uxbzlijqXHiyzmWMCGnCDXLycGUM2fXXrF5T4ykUuwqokLaV0va/EyUc7BlIKeOWSp5CV8WPMMc5xsSeyoOPWEhC7WSLx4A4ZsOTlmXRd00il8m++cDDPAFYWJBPN0F+wN/wDQbiPtz3JRMQlBbaPZ0/k3tjbp6ss6YBkTyVq6OT70WO43b9O6bS8RTVu8U0XZIn10dzhxDS4XbyNgN81EA5L8fvVF35rsMPao1GlC7S66oa9ZzGn9WmPsADyDeIplhIC2EJ0Dt91OPA9aa4XmdSAteYMynIbu+B7o3DtgpHFUkgmq6CPwYmdG9px5Hjv6LoSq64XqviWZIjFZDma/g7B4eJyQQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:1f", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:36:46.717460+00:00", "modification_date": "2025-02-10T15:37:27.194340+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2464"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e3644ade-10cb-492f-9f05-6c713aef1d99
+        status: 200 OK
+        code: 200
+        duration: 145.356791ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 109
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"backup","name":"packer-e2e-root-volume-sbs","volumes":{"c9584eaf-b206-4456-99fd-9853c8f7b8b7":{}}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 351
+        uncompressed: false
+        body: '{"task": {"id": "fefc55e1-d050-464a-b070-73dc572970c8", "description": "instance_backup", "status": "pending", "href_from": "/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98/action", "href_result": "/images/a77ece2d-74ac-4c43-bd0d-cf23cac99746", "started_at": "2025-02-10T15:37:31.570830+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "351"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:31 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/fefc55e1-d050-464a-b070-73dc572970c8
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 77f2d587-e308-4df5-9545-2a292a99d064
+        status: 202 Accepted
+        code: 202
+        duration: 602.124166ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/a77ece2d-74ac-4c43-bd0d-cf23cac99746
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 622
+        uncompressed: false
+        body: '{"image": {"id": "a77ece2d-74ac-4c43-bd0d-cf23cac99746", "name": "packer-e2e-root-volume-sbs", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "f3639014-608d-450b-844c-15e19a5a8f4c", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:37:31.116776+00:00", "modification_date": "2025-02-10T15:37:31.116776+00:00", "default_bootscript": null, "from_server": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "622"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9ab5daea-f697-48f1-8379-b01699f94c64
+        status: 200 OK
+        code: 200
+        duration: 87.163209ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8122c68c-01b5-46b9-8201-aefe8c91fa98
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e3a54c71-06ed-4760-b7c3-3447cb5f9598
+        status: 204 No Content
+        code: 204
+        duration: 522.590541ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c9584eaf-b206-4456-99fd-9853c8f7b8b7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bccfe6d6-39c1-418f-9153-502d09f0722b
+        status: 404 Not Found
+        code: 404
+        duration: 55.009208ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c9584eaf-b206-4456-99fd-9853c8f7b8b7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "c9584eaf-b206-4456-99fd-9853c8f7b8b7"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - be9f93c5-a0d2-4284-8a5d-d0c4ec498b7e
+        status: 404 Not Found
+        code: 404
+        duration: 30.283375ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c9584eaf-b206-4456-99fd-9853c8f7b8b7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 486
+        uncompressed: false
+        body: '{"id":"c9584eaf-b206-4456-99fd-9853c8f7b8b7","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_15k","size":50000000000,"project_id":"b577a333-d52a-4d86-9310-b413d5fe9bb1","created_at":"2025-02-10T15:36:46.854944Z","updated_at":"2025-02-10T15:37:32.258948Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"available","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":"2025-02-10T15:37:32.258948Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "486"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aa3ab29b-8c3e-4ab0-b8d2-56f3a713a286
+        status: 200 OK
+        code: 200
+        duration: 60.988625ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c9584eaf-b206-4456-99fd-9853c8f7b8b7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Feb 2025 15:37:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a70de7e-5d9f-44b7-8be6-201fe485109b
+        status: 204 No Content
+        code: 204
+        duration: 89.794583ms

--- a/internal/tests/testdata/packer-e2e-root-volume.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-root-volume.cassette.yaml
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14
+        content_length: 625
         uncompressed: false
-        body: '{"images": []}'
+        body: '{"images": [{"id": "a77ece2d-74ac-4c43-bd0d-cf23cac99746", "name": "packer-e2e-root-volume-sbs", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "f3639014-608d-450b-844c-15e19a5a8f4c", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:37:31.116776+00:00", "modification_date": "2025-02-10T15:37:31.116776+00:00", "default_bootscript": null, "from_server": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
-                - "14"
+                - "625"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:37 GMT
+                - Mon, 10 Feb 2025 15:37:35 GMT
             Link:
-                - </images?page=0&per_page=50&name=packer-e2e-root-volume>; rel="last"
+                - </images?page=1&per_page=50&name=packer-e2e-root-volume>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac8a1f04-184e-427d-a5c2-3508e95c0636
+                - 90fae6d0-78a0-48dc-8969-705922cc474d
             X-Total-Count:
-                - "0"
+                - "1"
         status: 200 OK
         code: 200
-        duration: 1.165868083s
+        duration: 741.265792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738936417&page=1
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1739201854&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:38 GMT
+                - Mon, 10 Feb 2025 15:37:35 GMT
             Link:
-                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738936417>; rel="last"
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1739201854>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 472e5fd4-3791-4915-850c-518cfc7bd8d1
+                - ef53bb3f-ecd0-4a85-88e2-5839b0cf18bf
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 160.512708ms
+        duration: 159.121333ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"packer-67a61061-edc1-e4ef-007d-0ed825d37d99","commercial_type":"PLAY2-PICO","image":"ubuntu_jammy","volumes":{"0":{"size":50000000000,"volume_type":"b_ssd"}},"boot_type":"local","project":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="]}'
+        body: '{"name":"packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf","commercial_type":"PLAY2-PICO","image":"ubuntu_jammy","volumes":{"0":{"size":50000000000,"volume_type":"b_ssd"}},"boot_type":"local","project":"b577a333-d52a-4d86-9310-b413d5fe9bb1","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="]}'
         form: {}
         headers:
             Content-Type:
@@ -135,7 +135,7 @@ interactions:
         trailer: {}
         content_length: 2937
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2937"
@@ -144,11 +144,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:39 GMT
+                - Mon, 10 Feb 2025 15:37:36 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -156,10 +156,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e8e0c06-1230-4f58-a908-a2894a546b34
+                - a56e9375-a9ba-467f-8525-9a7b181c0944
         status: 201 Created
         code: 201
-        duration: 847.713292ms
+        duration: 809.497958ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -178,7 +178,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -188,7 +188,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task": {"id": "e4470b98-3a29-4c57-9cc4-aab56d4103d4", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action", "href_result": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "started_at": "2025-02-07T13:53:40.815768+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "e4bbba92-5ab4-4028-a3ff-d1b423908fb6", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/b46d82ac-01ae-40c6-8c0e-a37138026141/action", "href_result": "/servers/b46d82ac-01ae-40c6-8c0e-a37138026141", "started_at": "2025-02-10T15:37:37.355962+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -197,11 +197,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:40 GMT
+                - Mon, 10 Feb 2025 15:37:36 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/e4470b98-3a29-4c57-9cc4-aab56d4103d4
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/e4bbba92-5ab4-4028-a3ff-d1b423908fb6
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -209,10 +209,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43ce8c69-2872-4185-88a1-ab57eef0d6b3
+                - 578c60cb-82a9-4b9b-8b42-ed829bb93983
         status: 202 Accepted
         code: 202
-        duration: 509.514125ms
+        duration: 238.987625ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -239,7 +239,7 @@ interactions:
         trailer: {}
         content_length: 2959
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.369952+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:37.180435+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2959"
@@ -248,9 +248,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:40 GMT
+                - Mon, 10 Feb 2025 15:37:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -258,10 +258,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 362d9ffa-c33b-4f09-90b6-063bfd605eb6
+                - c4ec34de-b670-4b60-ab38-b12021b4e130
         status: 200 OK
         code: 200
-        duration: 125.194459ms
+        duration: 138.614041ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -278,7 +278,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -286,20 +286,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3621
+        content_length: 3616
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:45.107113+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "dd0720a2-864e-4484-9d66-c296222e9cf8"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "dd0720a2-864e-4484-9d66-c296222e9cf8"}], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.027900+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3621"
+                - "3616"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:45 GMT
+                - Mon, 10 Feb 2025 15:37:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -307,10 +307,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1b173f1-ca46-4cbf-98c4-2f7aa6579be3
+                - 4997c1c6-7769-49f7-90ff-e5efa0a3f02e
         status: 200 OK
         code: 200
-        duration: 124.427333ms
+        duration: 178.307417ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -327,7 +327,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -335,20 +335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3621
+        content_length: 3616
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:45.107113+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "dd0720a2-864e-4484-9d66-c296222e9cf8"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "dd0720a2-864e-4484-9d66-c296222e9cf8"}], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.027900+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3621"
+                - "3616"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:45 GMT
+                - Mon, 10 Feb 2025 15:37:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,10 +356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eac7b43e-b51f-4a33-ab31-bc8728cdb624
+                - 74d72449-12dd-4b68-bc4b-aaa5e42ec9e1
         status: 200 OK
         code: 200
-        duration: 144.91625ms
+        duration: 193.3045ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -378,7 +378,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -388,7 +388,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task": {"id": "242b4fea-a8f6-47f4-8be9-3f82db99526f", "description": "server_poweroff", "status": "pending", "href_from": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action", "href_result": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "started_at": "2025-02-07T13:53:46.445451+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "658360ee-36e9-4609-aa83-13b013a7ecf5", "description": "server_poweroff", "status": "pending", "href_from": "/servers/b46d82ac-01ae-40c6-8c0e-a37138026141/action", "href_result": "/servers/b46d82ac-01ae-40c6-8c0e-a37138026141", "started_at": "2025-02-10T15:37:43.265320+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -397,11 +397,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:46 GMT
+                - Mon, 10 Feb 2025 15:37:43 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/242b4fea-a8f6-47f4-8be9-3f82db99526f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/658360ee-36e9-4609-aa83-13b013a7ecf5
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -409,10 +409,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0235a175-b5a8-412a-b7f8-0eb3e43c7d96
+                - 87829279-be44-4981-8070-4d0f815a63d2
         status: 202 Accepted
         code: 202
-        duration: 224.079ms
+        duration: 449.32975ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -429,7 +429,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -437,20 +437,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3581
+        content_length: 3576
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "dd0720a2-864e-4484-9d66-c296222e9cf8"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "dd0720a2-864e-4484-9d66-c296222e9cf8"}], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.937067+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3581"
+                - "3576"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:46 GMT
+                - Mon, 10 Feb 2025 15:37:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -458,10 +458,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1488113d-9a74-46dc-ba19-e8b71a23d5dc
+                - 666284b8-7880-41a3-b541-d294a8d07fb0
         status: 200 OK
         code: 200
-        duration: 146.718959ms
+        duration: 204.168292ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -486,20 +486,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3053
+        content_length: 3052
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.937067+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3053"
+                - "3052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:51 GMT
+                - Mon, 10 Feb 2025 15:37:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -507,10 +507,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebd7e052-7289-45b0-bfb2-b551309fedfa
+                - 79e24100-ad34-440c-b51b-81fe22a1d8a3
         status: 200 OK
         code: 200
-        duration: 144.778708ms
+        duration: 125.068292ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -527,7 +527,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -535,20 +535,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3053
+        content_length: 3052
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.937067+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3053"
+                - "3052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:53:56 GMT
+                - Mon, 10 Feb 2025 15:37:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,10 +556,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 10de935d-fff7-4092-a8bd-953fa29732fe
+                - 5fc2987d-74f0-416b-9088-1bef841bda44
         status: 200 OK
         code: 200
-        duration: 147.2055ms
+        duration: 159.731875ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -576,7 +576,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -584,20 +584,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3053
+        content_length: 3052
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.937067+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3053"
+                - "3052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:01 GMT
+                - Mon, 10 Feb 2025 15:37:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e24d254-089a-4ff9-8b47-0be169fb2b56
+                - 7492c48e-7872-4aaf-8f6e-5ba402631e0c
         status: 200 OK
         code: 200
-        duration: 99.387833ms
+        duration: 165.585917ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -625,7 +625,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3053
+        content_length: 3052
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.937067+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3053"
+                - "3052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:07 GMT
+                - Mon, 10 Feb 2025 15:38:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ffd529d-eda5-4828-8d3d-7f9c47894069
+                - 654b3c98-2864-4062-8bad-b8c425e074c5
         status: 200 OK
         code: 200
-        duration: 184.045792ms
+        duration: 198.949458ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -674,7 +674,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3053
+        content_length: 3052
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.937067+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3053"
+                - "3052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:11 GMT
+                - Mon, 10 Feb 2025 15:38:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84955d1e-4384-41d3-9d00-4ce6480f120b
+                - c62d52db-8671-4945-bf1c-a82f588b87b3
         status: 200 OK
         code: 200
-        duration: 124.824667ms
+        duration: 149.687ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -723,7 +723,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3053
+        content_length: 3052
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:42.937067+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "801", "node_id": "7"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3053"
+                - "3052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:17 GMT
+                - Mon, 10 Feb 2025 15:38:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51c5ec10-4b61-431f-a425-01aa7a695ae0
+                - 7110722b-7541-49ce-ae1a-76154a1d76f5
         status: 200 OK
         code: 200
-        duration: 146.045417ms
+        duration: 420.501458ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -772,7 +772,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: GET
       response:
         proto: HTTP/2.0
@@ -782,7 +782,7 @@ interactions:
         trailer: {}
         content_length: 2937
         uncompressed: false
-        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:54:21.950108+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": {"id": "b46d82ac-01ae-40c6-8c0e-a37138026141", "name": "packer-67aa1d3e-c4c7-b381-81cc-f62e161756bf"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:37:36.809921+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDKPzVX3wL1/MfIBh7lNfnsOrOxo8Yg2eFbtc+y6KlAG9/2glp6df7eDGP69ZDaTPh6ZvmpbaCRmqvjZDRH+NOENHRsSfDRMyXvaH3aCG3scX9tgvLOH59j7xTgRLlr8xsXjoVBv5RKFRNqWBNyB6/L3OUbsVS38WHIu2J+5N+sSMnfRXVUPFEbDBhgp+OQiKJryRz+JrO5gVCOrqDaEgIjs8t5g/BJgrB12ZUQ3gf83X18o0P02PQtrX+nthCZMyWzZ4z7bo1LbmVJ8gbBS1A0wR4XH93xZnkiuXRGvzHmMiDgtWgaEIFtFP0uOvIj2lFGfwF/T8XaNCuoIVU0+kgfs9kW+IRXqVE7aJLCipcJ3JHsjQ5d41XPodCvASYx4LphgPRPbRI/jL5LQfjRzjxf2X+xwk9B6CWhY8b6dUPcYZ9q3EkycP5bH64iBmy4DxSxWuzjD7WWHlrWERwK2ntDBxx+AGGGPo2eruTAlImOQARgH0GER3y1gWpdJQpvxKD07+yq2czvph38p6rMTxK1ii+GLe/WbY+8n7vQNEJ/E3wicQWtzTPB4xlzdnHl6/qRtOjyQgWHQ8m3kU66aNc8cXvSuZvS0U3C1pi1bYH03g7cz0kTFUHCo2mEdFLfiFZhQVz8SeR37ugWcb2rMAS9Wxe0QPT3lNHuuPa9CKSNJQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:27", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:38:17.136632+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2937"
@@ -791,9 +791,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:22 GMT
+                - Mon, 10 Feb 2025 15:38:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 61a9a7ce-4413-442e-9cae-bf949ef10e90
+                - 4a9669ab-e1c0-4790-a04f-8fae9ff21002
         status: 200 OK
         code: 200
-        duration: 96.880959ms
+        duration: 117.167417ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -816,14 +816,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"action":"backup","name":"packer-e2e-root-volume","volumes":{"8f15d280-e2ce-4d2d-a7de-af81b6fb67ef":{}}}'
+        body: '{"action":"backup","name":"packer-e2e-root-volume","volumes":{"234005ad-b951-4fb2-ba3e-cccf7d928952":{}}}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -833,7 +833,7 @@ interactions:
         trailer: {}
         content_length: 351
         uncompressed: false
-        body: '{"task": {"id": "03a3e84a-8904-4c84-9a35-9a1243e49c87", "description": "instance_backup", "status": "pending", "href_from": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action", "href_result": "/images/851ed46e-aa23-4733-8610-6e0b36d6147e", "started_at": "2025-02-07T13:54:23.291763+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "68ef7fb4-4953-4c48-9f45-a51687d9b00f", "description": "instance_backup", "status": "pending", "href_from": "/servers/b46d82ac-01ae-40c6-8c0e-a37138026141/action", "href_result": "/images/b96d1e58-acac-4f7f-9511-b195d3a6851a", "started_at": "2025-02-10T15:38:20.388644+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "351"
@@ -842,11 +842,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:23 GMT
+                - Mon, 10 Feb 2025 15:38:20 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/03a3e84a-8904-4c84-9a35-9a1243e49c87
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/68ef7fb4-4953-4c48-9f45-a51687d9b00f
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -854,10 +854,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d98e3c69-85d3-4fdc-8831-1bac26beece7
+                - 77f4519a-ddd6-4ae8-8be7-37522e5420e3
         status: 202 Accepted
         code: 202
-        duration: 750.59825ms
+        duration: 612.398083ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -874,7 +874,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/851ed46e-aa23-4733-8610-6e0b36d6147e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b96d1e58-acac-4f7f-9511-b195d3a6851a
         method: GET
       response:
         proto: HTTP/2.0
@@ -884,7 +884,7 @@ interactions:
         trailer: {}
         content_length: 649
         uncompressed: false
-        body: '{"image": {"id": "851ed46e-aa23-4733-8610-6e0b36d6147e", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"id": "71d3b9eb-8fab-484d-b59e-28c7929bcb3b", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:54:22.625071+00:00", "modification_date": "2025-02-07T13:54:22.625071+00:00", "default_bootscript": null, "from_server": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "state": "creating", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"image": {"id": "b96d1e58-acac-4f7f-9511-b195d3a6851a", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"id": "3d76deb4-e252-4ac1-b709-6eb4e4698d79", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:38:20.019704+00:00", "modification_date": "2025-02-10T15:38:20.019704+00:00", "default_bootscript": null, "from_server": "b46d82ac-01ae-40c6-8c0e-a37138026141", "state": "creating", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "649"
@@ -893,9 +893,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:22 GMT
+                - Mon, 10 Feb 2025 15:38:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f2aa113-2f5b-41d8-9a2a-1ee6ec4572d4
+                - d5c91ac7-89fa-4c09-8a17-838b0153b955
         status: 200 OK
         code: 200
-        duration: 69.440958ms
+        duration: 71.297917ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -923,7 +923,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/851ed46e-aa23-4733-8610-6e0b36d6147e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b96d1e58-acac-4f7f-9511-b195d3a6851a
         method: GET
       response:
         proto: HTTP/2.0
@@ -933,7 +933,7 @@ interactions:
         trailer: {}
         content_length: 650
         uncompressed: false
-        body: '{"image": {"id": "851ed46e-aa23-4733-8610-6e0b36d6147e", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"id": "71d3b9eb-8fab-484d-b59e-28c7929bcb3b", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:54:22.625071+00:00", "modification_date": "2025-02-07T13:54:22.625071+00:00", "default_bootscript": null, "from_server": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"image": {"id": "b96d1e58-acac-4f7f-9511-b195d3a6851a", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"id": "3d76deb4-e252-4ac1-b709-6eb4e4698d79", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:38:20.019704+00:00", "modification_date": "2025-02-10T15:38:20.019704+00:00", "default_bootscript": null, "from_server": "b46d82ac-01ae-40c6-8c0e-a37138026141", "state": "available", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "650"
@@ -942,9 +942,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:28 GMT
+                - Mon, 10 Feb 2025 15:38:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22c22be2-74cb-4ec4-8d73-0f7d5feabcff
+                - 65d4080b-8ce9-42a9-a19f-300363ca8f82
         status: 200 OK
         code: 200
-        duration: 82.874334ms
+        duration: 107.344417ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -972,7 +972,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b46d82ac-01ae-40c6-8c0e-a37138026141
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -989,9 +989,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:28 GMT
+                - Mon, 10 Feb 2025 15:38:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +999,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53ea11cd-d533-4ed3-a2e1-03ad1e0155be
+                - ce2915ec-67fa-4823-ba28-f5e8504c1684
         status: 204 No Content
         code: 204
-        duration: 178.924875ms
+        duration: 176.700417ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1019,7 +1019,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f15d280-e2ce-4d2d-a7de-af81b6fb67ef
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/234005ad-b951-4fb2-ba3e-cccf7d928952
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,7 +1029,7 @@ interactions:
         trailer: {}
         content_length: 450
         uncompressed: false
-        body: '{"volume": {"id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": null, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:54:28.521951+00:00", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"volume": {"id": "234005ad-b951-4fb2-ba3e-cccf7d928952", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "server": null, "size": 50000000000, "state": "available", "creation_date": "2025-02-10T15:37:36.809921+00:00", "modification_date": "2025-02-10T15:38:25.745516+00:00", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "450"
@@ -1038,9 +1038,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:28 GMT
+                - Mon, 10 Feb 2025 15:38:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1048,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1876071-1243-47a2-ab32-9fbfe07067be
+                - 85bba0a0-f2b1-4ddc-bf47-94cacb296338
         status: 200 OK
         code: 200
-        duration: 58.415875ms
+        duration: 59.165917ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1068,7 +1068,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f15d280-e2ce-4d2d-a7de-af81b6fb67ef
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/234005ad-b951-4fb2-ba3e-cccf7d928952
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1085,9 +1085,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:28 GMT
+                - Mon, 10 Feb 2025 15:38:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1095,7 +1095,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1ef6df2-f3fd-45b1-a3ff-66ad490213ad
+                - eaa0f00d-9bbd-459a-b4aa-2e7eb9d21fba
         status: 204 No Content
         code: 204
-        duration: 105.669708ms
+        duration: 158.863833ms

--- a/internal/tests/testdata/packer-e2e-root-volume.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-root-volume.cassette.yaml
@@ -1,0 +1,1101 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-root-volume&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"images": []}'
+        headers:
+            Content-Length:
+                - "14"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:37 GMT
+            Link:
+                - </images?page=0&per_page=50&name=packer-e2e-root-volume>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ac8a1f04-184e-427d-a5c2-3508e95c0636
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.165868083s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738936417&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"snapshots": []}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:38 GMT
+            Link:
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738936417>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 472e5fd4-3791-4915-850c-518cfc7bd8d1
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 160.512708ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 987
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"packer-67a61061-edc1-e4ef-007d-0ed825d37d99","commercial_type":"PLAY2-PICO","image":"ubuntu_jammy","volumes":{"0":{"size":50000000000,"volume_type":"b_ssd"}},"boot_type":"local","project":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2937
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2937"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:39 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4e8e0c06-1230-4f58-a908-a2894a546b34
+        status: 201 Created
+        code: 201
+        duration: 847.713292ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 20
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"poweron"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 357
+        uncompressed: false
+        body: '{"task": {"id": "e4470b98-3a29-4c57-9cc4-aab56d4103d4", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action", "href_result": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "started_at": "2025-02-07T13:53:40.815768+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "357"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:40 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/e4470b98-3a29-4c57-9cc4-aab56d4103d4
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 43ce8c69-2872-4185-88a1-ab57eef0d6b3
+        status: 202 Accepted
+        code: 202
+        duration: 509.514125ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2959
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.369952+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2959"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 362d9ffa-c33b-4f09-90b6-063bfd605eb6
+        status: 200 OK
+        code: 200
+        duration: 125.194459ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3621
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:45.107113+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3621"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c1b173f1-ca46-4cbf-98c4-2f7aa6579be3
+        status: 200 OK
+        code: 200
+        duration: 124.427333ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3621
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:45.107113+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3621"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eac7b43e-b51f-4a33-ab31-bc8728cdb624
+        status: 200 OK
+        code: 200
+        duration: 144.91625ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 21
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"poweroff"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 352
+        uncompressed: false
+        body: '{"task": {"id": "242b4fea-a8f6-47f4-8be9-3f82db99526f", "description": "server_poweroff", "status": "pending", "href_from": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action", "href_result": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "started_at": "2025-02-07T13:53:46.445451+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "352"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:46 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/242b4fea-a8f6-47f4-8be9-3f82db99526f
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0235a175-b5a8-412a-b7f8-0eb3e43c7d96
+        status: 202 Accepted
+        code: 202
+        duration: 224.079ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3581
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9685ef45-dce8-4b34-9c75-e5fe5246e905"}], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3581"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1488113d-9a74-46dc-ba19-e8b71a23d5dc
+        status: 200 OK
+        code: 200
+        duration: 146.718959ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3053
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3053"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ebd7e052-7289-45b0-bfb2-b551309fedfa
+        status: 200 OK
+        code: 200
+        duration: 144.778708ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3053
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3053"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:53:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10de935d-fff7-4092-a8bd-953fa29732fe
+        status: 200 OK
+        code: 200
+        duration: 147.2055ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3053
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3053"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9e24d254-089a-4ff9-8b47-0be169fb2b56
+        status: 200 OK
+        code: 200
+        duration: 99.387833ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3053
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3053"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8ffd529d-eda5-4828-8d3d-7f9c47894069
+        status: 200 OK
+        code: 200
+        duration: 184.045792ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3053
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3053"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 84955d1e-4384-41d3-9d00-4ce6480f120b
+        status: 200 OK
+        code: 200
+        duration: 124.824667ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3053
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:46.278254+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "60", "hypervisor_id": "701", "node_id": "90"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3053"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 51c5ec10-4b61-431f-a425-01aa7a695ae0
+        status: 200 OK
+        code: 200
+        duration: 146.045417ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2937
+        uncompressed: false
+        body: '{"server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "arch": "x86_64", "commercial_type": "PLAY2-PICO", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": {"id": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "name": "packer-67a61061-edc1-e4ef-007d-0ed825d37d99"}, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:53:40.009800+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQChMpMdOF0UK0bhj1Y1+s/3mUsBTBJ12rgzzsy1JPzDpSKjdp75hcX03n3m+oGO1oqhqEi3SdrsPRtjoKI5+ghCfiKbyAdBfPkW45i50S/WJr5P4jPBkg0oLse2zCGhjQjFhT2u5H+cq1uqrXtsfy4vsBTU+R0bymXZJzhPoJFwDhIvje9ZYtvLXLjQYV1SNrTWJX2I4LCA3V5mtpXBFyY88rAoOkeXgKSONpcA96Cp6Wa1XH1c7LhO5y3hqkBszp6UDRVTJmqBorc1WOmaaMoQhsEvEOxiDNxP/2NcNKiJu2YniGhfjXFrfFfqwk8yzBKdq4mYLPPiwoEv7nlMJfToUT/A1zmt8yiba9YRywD+XdFkf7DObdOeFYz6pK1kOZJFPefFdMHLnMjlqsY6NFN0oinPsZ1806JKdggN9DOyMPl7/2t3v2QyP8Tc2r3wScTsjJ3gAHN1mlzDtNgT6rtjL3ox39FelW5b4ZSGHGaX62yJQmOBDb18iiRLPcXx+7lK+g0upfHMNzhKvndRfBjEP2Rzaxb+p+g2x1fVQXYP1DDPlXagnInNpmtR4i42vlnd8yoF3WUXgrO2K8z1jrtgjIrOhI8NoIwGTFtPNXEHhke7g92ubZ1DAzeD70yTJIyomiwo0JW/DeHvXfK/MlA0BBfiFnC0kTO79lJxpDEHWw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:9b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:54:21.950108+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2937"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 61a9a7ce-4413-442e-9cae-bf949ef10e90
+        status: 200 OK
+        code: 200
+        duration: 96.880959ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 105
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"backup","name":"packer-e2e-root-volume","volumes":{"8f15d280-e2ce-4d2d-a7de-af81b6fb67ef":{}}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 351
+        uncompressed: false
+        body: '{"task": {"id": "03a3e84a-8904-4c84-9a35-9a1243e49c87", "description": "instance_backup", "status": "pending", "href_from": "/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c/action", "href_result": "/images/851ed46e-aa23-4733-8610-6e0b36d6147e", "started_at": "2025-02-07T13:54:23.291763+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "351"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:23 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/03a3e84a-8904-4c84-9a35-9a1243e49c87
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d98e3c69-85d3-4fdc-8831-1bac26beece7
+        status: 202 Accepted
+        code: 202
+        duration: 750.59825ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/851ed46e-aa23-4733-8610-6e0b36d6147e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 649
+        uncompressed: false
+        body: '{"image": {"id": "851ed46e-aa23-4733-8610-6e0b36d6147e", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"id": "71d3b9eb-8fab-484d-b59e-28c7929bcb3b", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:54:22.625071+00:00", "modification_date": "2025-02-07T13:54:22.625071+00:00", "default_bootscript": null, "from_server": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "state": "creating", "tags": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4f2aa113-2f5b-41d8-9a2a-1ee6ec4572d4
+        status: 200 OK
+        code: 200
+        duration: 69.440958ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/851ed46e-aa23-4733-8610-6e0b36d6147e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 650
+        uncompressed: false
+        body: '{"image": {"id": "851ed46e-aa23-4733-8610-6e0b36d6147e", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"id": "71d3b9eb-8fab-484d-b59e-28c7929bcb3b", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:54:22.625071+00:00", "modification_date": "2025-02-07T13:54:22.625071+00:00", "default_bootscript": null, "from_server": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "650"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22c22be2-74cb-4ec4-8d73-0f7d5feabcff
+        status: 200 OK
+        code: 200
+        duration: 82.874334ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ac3b748-b2e1-4332-a59e-9725c41c8d1c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 53ea11cd-d533-4ed3-a2e1-03ad1e0155be
+        status: 204 No Content
+        code: 204
+        duration: 178.924875ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f15d280-e2ce-4d2d-a7de-af81b6fb67ef
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 450
+        uncompressed: false
+        body: '{"volume": {"id": "8f15d280-e2ce-4d2d-a7de-af81b6fb67ef", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "server": null, "size": 50000000000, "state": "available", "creation_date": "2025-02-07T13:53:40.009800+00:00", "modification_date": "2025-02-07T13:54:28.521951+00:00", "tags": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "450"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c1876071-1243-47a2-ab32-9fbfe07067be
+        status: 200 OK
+        code: 200
+        duration: 58.415875ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f15d280-e2ce-4d2d-a7de-af81b6fb67ef
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a1ef6df2-f3fd-45b1-a3ff-66ad490213ad
+        status: 204 No Content
+        code: 204
+        duration: 105.669708ms

--- a/internal/tests/testdata/packer-e2e-simple.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-simple.cassette.yaml
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:31 GMT
+                - Mon, 10 Feb 2025 15:38:27 GMT
             Link:
                 - </images?page=0&per_page=50&name=packer-e2e-simple>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83d24c31-d75d-4dc5-98b1-e41cce63c1e0
+                - 7c3f0865-f24e-4ed8-8354-ed6b835f9e4b
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 717.637417ms
+        duration: 404.80925ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738936470&page=1
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1739201907&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:31 GMT
+                - Mon, 10 Feb 2025 15:38:27 GMT
             Link:
-                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738936470>; rel="last"
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1739201907>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da77d839-54a5-47e1-bdd5-74ab99972d4d
+                - 333ab444-12c1-4ac5-b3d1-3618be4a9c5a
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 146.438833ms
+        duration: 508.982041ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"packer-67a61096-91f3-ff78-2b6a-b57a76dcc715","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","boot_type":"local","project":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="]}'
+        body: '{"name":"packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","boot_type":"local","project":"b577a333-d52a-4d86-9310-b413d5fe9bb1","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="]}'
         form: {}
         headers:
             Content-Type:
@@ -135,7 +135,7 @@ interactions:
         trailer: {}
         content_length: 2462
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:33.499296+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:31.178214+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2462"
@@ -144,11 +144,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:33 GMT
+                - Mon, 10 Feb 2025 15:38:31 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -156,10 +156,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e23c94a4-e53c-4b11-9eea-4e4ebda628a1
+                - 893c7a31-a3f5-46b8-ba2d-1643aade77f8
         status: 201 Created
         code: 201
-        duration: 1.338121s
+        duration: 1.7231115s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -178,7 +178,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -188,7 +188,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task": {"id": "5f80df76-42ff-47a6-9402-ffe91ec07fcb", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action", "href_result": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d", "started_at": "2025-02-07T13:54:34.553289+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "63712494-930b-441a-9197-3edb10aa6f39", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7/action", "href_result": "/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "started_at": "2025-02-10T15:38:32.605154+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -197,11 +197,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:34 GMT
+                - Mon, 10 Feb 2025 15:38:32 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5f80df76-42ff-47a6-9402-ffe91ec07fcb
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/63712494-930b-441a-9197-3edb10aa6f39
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -209,10 +209,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73eb22d0-3d62-4721-9f4a-1f00692d7885
+                - 52457b01-b5d3-422b-bdde-dc45667cefd4
         status: 202 Accepted
         code: 202
-        duration: 510.583542ms
+        duration: 305.392834ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -239,7 +239,7 @@ interactions:
         trailer: {}
         content_length: 2484
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:34.128554+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:32.429719+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2484"
@@ -248,9 +248,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:34 GMT
+                - Mon, 10 Feb 2025 15:38:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -258,10 +258,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22ec1446-ecf1-457b-b1c8-7fabb9685e45
+                - 68027e04-2dbb-4237-ba59-89edcc6f4aa9
         status: 200 OK
         code: 200
-        duration: 140.008375ms
+        duration: 131.153334ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -278,7 +278,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -286,20 +286,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3146
+        content_length: 3143
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:37.311123+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b9b9f59d-9c2f-4926-b377-bfd2288f1802"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b9b9f59d-9c2f-4926-b377-bfd2288f1802"}], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:35.417221+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3146"
+                - "3143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:39 GMT
+                - Mon, 10 Feb 2025 15:38:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -307,10 +307,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be99ffe1-7e06-4d4a-92af-c31c54a9afc3
+                - dd150167-0ae8-4cd1-a45d-71b890ed43a2
         status: 200 OK
         code: 200
-        duration: 158.767875ms
+        duration: 165.166458ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -327,7 +327,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -335,20 +335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3146
+        content_length: 3143
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:37.311123+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b9b9f59d-9c2f-4926-b377-bfd2288f1802"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b9b9f59d-9c2f-4926-b377-bfd2288f1802"}], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:35.417221+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3146"
+                - "3143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:39 GMT
+                - Mon, 10 Feb 2025 15:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,10 +356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eec07036-d733-47b4-ac79-0fe9d4cf4561
+                - 98e64021-511c-40b1-bb73-8894c50added
         status: 200 OK
         code: 200
-        duration: 150.927917ms
+        duration: 149.215125ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -378,7 +378,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -388,7 +388,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task": {"id": "e6b70b62-8dda-4775-9941-c23e382215c9", "description": "server_poweroff", "status": "pending", "href_from": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action", "href_result": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d", "started_at": "2025-02-07T13:54:40.263602+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "065d13d2-9e7b-4c26-8216-c66798ae445e", "description": "server_poweroff", "status": "pending", "href_from": "/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7/action", "href_result": "/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "started_at": "2025-02-10T15:38:38.407307+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -397,11 +397,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:40 GMT
+                - Mon, 10 Feb 2025 15:38:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/e6b70b62-8dda-4775-9941-c23e382215c9
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/065d13d2-9e7b-4c26-8216-c66798ae445e
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -409,10 +409,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c118c23-551e-47cc-8ddd-fd79a9377dbd
+                - fc4ce2a9-99e5-40d5-85ab-bcb9ef8d1a77
         status: 202 Accepted
         code: 202
-        duration: 274.2345ms
+        duration: 267.339334ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -429,7 +429,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -437,20 +437,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3106
+        content_length: 3103
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b9b9f59d-9c2f-4926-b377-bfd2288f1802"}, "public_ips": [{"id": "5e153afc-a565-4bc9-a26c-81e5740ea1ed", "address": "163.172.184.6", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b9b9f59d-9c2f-4926-b377-bfd2288f1802"}], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:38.205427+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3106"
+                - "3103"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:40 GMT
+                - Mon, 10 Feb 2025 15:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -458,10 +458,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f41999ce-5530-43fc-bb77-3e61d353b54f
+                - caae61ce-067e-44c0-8c5d-cf272f3dbc75
         status: 200 OK
         code: 200
-        duration: 132.241959ms
+        duration: 133.483417ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -486,20 +486,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2578
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:38.205427+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2578"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:45 GMT
+                - Mon, 10 Feb 2025 15:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -507,10 +507,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4250d78-7a3f-469e-a1f4-21de0e7bff25
+                - 92b00641-5b1d-4f25-87b5-acbd29d70350
         status: 200 OK
         code: 200
-        duration: 156.568125ms
+        duration: 305.266167ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -527,7 +527,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -535,20 +535,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2578
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:38.205427+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2578"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:50 GMT
+                - Mon, 10 Feb 2025 15:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,10 +556,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ebcd96c-1ca0-4ad0-8d1b-755108aede54
+                - eb110dc2-0db4-4f5f-a6c6-4cf6aea71e3b
         status: 200 OK
         code: 200
-        duration: 194.662042ms
+        duration: 182.944291ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -576,7 +576,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -584,20 +584,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2578
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:38.205427+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2578"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:54:55 GMT
+                - Mon, 10 Feb 2025 15:38:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b92dd000-6afc-4e87-bd45-09eb00be6904
+                - e3e2d934-92e4-4ce3-81f5-2371c0940ac9
         status: 200 OK
         code: 200
-        duration: 295.203333ms
+        duration: 151.370459ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -625,7 +625,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2578
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:38.205427+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2578"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:00 GMT
+                - Mon, 10 Feb 2025 15:38:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39907b6f-28ce-41e6-83ca-7d9ac96d0b91
+                - e7ded4f6-36b6-4777-b379-73efeb62c590
         status: 200 OK
         code: 200
-        duration: 147.071791ms
+        duration: 144.391459ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -674,7 +674,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2578
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:38.205427+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2578"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:05 GMT
+                - Mon, 10 Feb 2025 15:39:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44ac09a8-e7bc-4244-bb27-ec143213995f
+                - a95d1b4b-feba-4c2f-8df6-b2abd65f2002
         status: 200 OK
         code: 200
-        duration: 130.289666ms
+        duration: 171.385834ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -723,7 +723,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2578
+        content_length: 2579
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:38:38.205427+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "1001", "node_id": "16"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2578"
+                - "2579"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:11 GMT
+                - Mon, 10 Feb 2025 15:39:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c21e9596-73e3-4a36-8dda-5f8c027af964
+                - fee10f37-96c4-47d8-8fbd-45191a6e9848
         status: 200 OK
         code: 200
-        duration: 188.285167ms
+        duration: 348.102125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -772,7 +772,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: GET
       response:
         proto: HTTP/2.0
@@ -782,7 +782,7 @@ interactions:
         trailer: {}
         content_length: 2462
         uncompressed: false
-        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:55:13.905284+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "name": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "hostname": "packer-67aa1d73-f2e1-4c15-3a7b-d8b6511a6889", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFjHzA/c3ZSJE1cDb2jT6j6gMLTNyk/gEu8WtQxU2cXXPD/iZgCgRLjRXAhAieWWkRspqIXPi0Co8JUf9+GQca3UK0LVNceji5oUlq0ORhr0gB58VxaGbzOGYDLyoDH4tM47c2n552/3IsDy6hby8ZjyQ/iDbYt2L3wfS1l47Pd86MKUS+RFQsJmOfId47/g9/klH+Q9BL954jv2YhNrHJnndQafDf6s9ehJo92hdDT9JZQxTDtRlHj6bVKegsPAeuL5gGUEgHczfn1xOC6mqsyvabKjlK4gZAK61RKLTH2ExJHrtV28KIH/9BsfgBTPRASZ2Q24T1kF+HZmtUM40Ii2f6pqZdu/DSlhGNHxetOvv5JigYG9OpJPQzpeHGP/0SrTpD7yhXqsJdm40fJWWI+LFBRYQJbAfhA015yDgBRvKFxLzlwVNiSjKh0kGjUXRLTAPxdmQrp33BYsQ8h3BKVb6Ma74mXUWpVikdbWQ5djp7j2VTPl0oFiBVOaf8rmALKgBc0F+O7DQB5j0szC56D9atZ2UB9mtbzWiTSckFTpNBjvsRUF12AUbMPGLGWwZNzERJG6B59rsqU4PcuC91GzDhkNomRynV8FXZmXIH7TTh6m5uJoSlbmh5yWnhmlqqNEh/tFmUc6EJDPSlSjES4p2odOM9xYDkazdqKRONGw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:93:2b:3b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-10T15:38:31.178214+00:00", "modification_date": "2025-02-10T15:39:11.775577+00:00", "bootscript": null, "security_group": {"id": "0a1339e8-9a2a-4650-badf-eb97dda33105", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "2462"
@@ -791,9 +791,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:16 GMT
+                - Mon, 10 Feb 2025 15:39:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5682cba4-2c5e-4703-8598-99f56ca097d0
+                - 021b1ba6-3fa3-49b0-a135-c560212a1064
         status: 200 OK
         code: 200
-        duration: 121.732584ms
+        duration: 138.693834ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -816,14 +816,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"action":"backup","name":"packer-e2e-simple","volumes":{"e70056f2-ccfb-4c2a-8077-fb39a023a619":{}}}'
+        body: '{"action":"backup","name":"packer-e2e-simple","volumes":{"0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234":{}}}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -833,7 +833,7 @@ interactions:
         trailer: {}
         content_length: 351
         uncompressed: false
-        body: '{"task": {"id": "1e30dd95-afa2-42c0-9a9a-667d3d4a0b27", "description": "instance_backup", "status": "pending", "href_from": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action", "href_result": "/images/24fcdd8e-b440-4a4f-9328-1e7116fa0e5c", "started_at": "2025-02-07T13:55:17.242110+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "3ccd2184-5860-421b-960c-4b834c968482", "description": "instance_backup", "status": "pending", "href_from": "/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7/action", "href_result": "/images/ec860961-5a7e-4126-9c69-af4591d076f0", "started_at": "2025-02-10T15:39:15.708030+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "351"
@@ -842,11 +842,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:17 GMT
+                - Mon, 10 Feb 2025 15:39:15 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1e30dd95-afa2-42c0-9a9a-667d3d4a0b27
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3ccd2184-5860-421b-960c-4b834c968482
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -854,10 +854,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee4b1b07-6383-4a39-b280-363cdb3dc120
+                - 4e7325a1-720c-4bf5-80ca-0a411661306b
         status: 202 Accepted
         code: 202
-        duration: 579.393709ms
+        duration: 794.079042ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -874,7 +874,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/24fcdd8e-b440-4a4f-9328-1e7116fa0e5c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/ec860961-5a7e-4126-9c69-af4591d076f0
         method: GET
       response:
         proto: HTTP/2.0
@@ -884,7 +884,7 @@ interactions:
         trailer: {}
         content_length: 613
         uncompressed: false
-        body: '{"image": {"id": "24fcdd8e-b440-4a4f-9328-1e7116fa0e5c", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f9804316-e919-4840-9f24-71fd727e3262", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:55:16.761993+00:00", "modification_date": "2025-02-07T13:55:16.761993+00:00", "default_bootscript": null, "from_server": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"image": {"id": "ec860961-5a7e-4126-9c69-af4591d076f0", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "3a172cdf-c167-4979-b8fb-9e1a77eec206", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:39:15.062024+00:00", "modification_date": "2025-02-10T15:39:15.062024+00:00", "default_bootscript": null, "from_server": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "state": "available", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "613"
@@ -893,9 +893,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:17 GMT
+                - Mon, 10 Feb 2025 15:39:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96311f1a-e91c-479e-8a8b-0632017b1ac7
+                - c9f2f206-683b-473a-bbb2-0be429a93491
         status: 200 OK
         code: 200
-        duration: 82.733416ms
+        duration: 93.838709ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -923,7 +923,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -940,9 +940,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:17 GMT
+                - Mon, 10 Feb 2025 15:39:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,10 +950,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa2c061c-86a2-476d-bb58-d3c82ea98a6c
+                - 77a46d8c-2d8a-4b48-956d-983a06457d63
         status: 204 No Content
         code: 204
-        duration: 320.961416ms
+        duration: 314.6745ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -970,7 +970,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,7 +980,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "e70056f2-ccfb-4c2a-8077-fb39a023a619"}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234"}'
         headers:
             Content-Length:
                 - "143"
@@ -989,9 +989,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:17 GMT
+                - Mon, 10 Feb 2025 15:39:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +999,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa964ee9-82a4-4de1-8407-dad641aab793
+                - 615fea0e-d645-4166-832f-485d8c921ca0
         status: 404 Not Found
         code: 404
-        duration: 43.859166ms
+        duration: 33.233458ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1019,7 +1019,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1029,7 +1029,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "e70056f2-ccfb-4c2a-8077-fb39a023a619"}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234"}'
         headers:
             Content-Length:
                 - "143"
@@ -1038,9 +1038,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:17 GMT
+                - Mon, 10 Feb 2025 15:39:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1048,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 592085ce-ee32-4f03-9db4-221ec30b86c4
+                - 97f8ad84-fdb8-4c26-bb02-649586c7e350
         status: 404 Not Found
         code: 404
-        duration: 32.638834ms
+        duration: 37.548417ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1068,7 +1068,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,20 +1076,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 487
+        content_length: 484
         uncompressed: false
-        body: '{"id":"e70056f2-ccfb-4c2a-8077-fb39a023a619","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:54:33.632945Z","updated_at":"2025-02-07T13:55:17.711695Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"snapshotting","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:55:17.711695Z","zone":"fr-par-1"}'
+        body: '{"id":"0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"b577a333-d52a-4d86-9310-b413d5fe9bb1","created_at":"2025-02-10T15:38:31.356719Z","updated_at":"2025-02-10T15:39:16.243852Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-10T15:39:16.243852Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "487"
+                - "484"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:17 GMT
+                - Mon, 10 Feb 2025 15:39:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1097,10 +1097,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d93119e-3cee-494c-a525-0895a56e5162
+                - 90064213-f40a-47c0-a5ad-d6e7ac32eb1c
         status: 200 OK
         code: 200
-        duration: 54.831583ms
+        duration: 46.240208ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1117,56 +1117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"id":"e70056f2-ccfb-4c2a-8077-fb39a023a619","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:54:33.632945Z","updated_at":"2025-02-07T13:55:17.711695Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:55:17.711695Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 07 Feb 2025 13:55:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d3c54093-79cf-469f-9bec-1d96b6277787
-        status: 200 OK
-        code: 200
-        duration: 57.190125ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0bfa9a8c-8b6c-4e44-ad74-f46c2b03f234
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1183,9 +1134,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:23 GMT
+                - Mon, 10 Feb 2025 15:39:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1193,7 +1144,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0bfacfeb-b4a7-44ed-8ef6-f0972d339022
+                - e5ba2480-fd93-44ae-847f-5f447493fce4
         status: 204 No Content
         code: 204
-        duration: 91.123625ms
+        duration: 85.880458ms

--- a/internal/tests/testdata/packer-e2e-simple.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-simple.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-simple&page=1
         method: GET
       response:
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:05 GMT
+                - Fri, 07 Feb 2025 13:54:31 GMT
             Link:
                 - </images?page=0&per_page=50&name=packer-e2e-simple>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7035ad85-5fe0-415d-a0c5-5f95c84a448b
+                - 83d24c31-d75d-4dc5-98b1-e41cce63c1e0
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 4.690355041s
+        duration: 717.637417ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1736760661&page=1
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?name=snapshot-packer-1738936470&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:06 GMT
+                - Fri, 07 Feb 2025 13:54:31 GMT
             Link:
-                - </snapshots?page=0&per_page=50&name=snapshot-packer-1736760661>; rel="last"
+                - </snapshots?page=0&per_page=50&name=snapshot-packer-1738936470>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,79 +101,30 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a55523c-0217-4a85-a29d-8cbbb7a11d98
+                - da77d839-54a5-47e1-bdd5-74ab99972d4d
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 204.380416ms
+        duration: 146.438833ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 926
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=unknown_type&zone=fr-par-1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2562
-        uncompressed: false
-        body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5", "arch":"arm64", "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4", "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G", "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"], "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G", "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G", "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G", "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G", "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"], "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G", "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G", "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G", "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G", "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"], "label":"ubuntu_jammy", "type":"instance_sbs"}, {"id":"7044ae1e-a35d-4364-a962-93811c845f2f", "arch":"arm64", "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4", "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G", "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"], "label":"ubuntu_jammy", "type":"instance_sbs"}], "total_count":4}'
-        headers:
-            Content-Length:
-                - "2562"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 13 Jan 2025 09:31:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a224fec6-8dcd-4697-89b1-bb66d5c19ca8
-        status: 200 OK
-        code: 200
-        duration: 126.78675ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 950
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"packer-6784dd55-014e-8cfe-e298-d4d936bf312f","commercial_type":"PRO2-XXS","image":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","boot_type":"local","project":"ac06b5eb-7546-4f57-9ffb-5425d6bb291b","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="]}'
+        body: '{"name":"packer-67a61096-91f3-ff78-2b6a-b57a76dcc715","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","boot_type":"local","project":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +133,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2935
+        content_length: 2462
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:33.499296+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2935"
+                - "2462"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:07 GMT
+                - Fri, 07 Feb 2025 13:54:33 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,11 +156,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38c9f4f9-c47a-44a2-a0fa-79bc91d92e71
+                - e23c94a4-e53c-4b11-9eea-4e4ebda628a1
         status: 201 Created
         code: 201
-        duration: 504.369208ms
-    - id: 4
+        duration: 1.338121s
+    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -226,8 +177,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c/action
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -237,7 +188,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task": {"id": "fe550818-a38b-4b6a-a81d-2fb69508e027", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c/action", "href_result": "/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c", "started_at": "2025-01-13T09:31:08.038537+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "5f80df76-42ff-47a6-9402-ffe91ec07fcb", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action", "href_result": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d", "started_at": "2025-02-07T13:54:34.553289+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -246,11 +197,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:07 GMT
+                - Fri, 07 Feb 2025 13:54:34 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/fe550818-a38b-4b6a-a81d-2fb69508e027
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5f80df76-42ff-47a6-9402-ffe91ec07fcb
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -258,10 +209,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4e8305b-cc91-4e17-95e8-45a718b6e8b7
+                - 73eb22d0-3d62-4721-9f4a-1f00692d7885
         status: 202 Accepted
         code: 202
-        duration: 261.288084ms
+        duration: 510.583542ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2484
+        uncompressed: false
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:34.128554+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2484"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22ec1446-ecf1-457b-b1c8-7fabb9685e45
+        status: 200 OK
+        code: 200
+        duration: 140.008375ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -277,8 +277,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -286,20 +286,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2957
+        content_length: 3146
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.874253+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:37.311123+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2957"
+                - "3146"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:08 GMT
+                - Fri, 07 Feb 2025 13:54:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -307,10 +307,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bb19e94-1f4b-4ea0-b2dc-d7a7b4daf2d5
+                - be99ffe1-7e06-4d4a-92af-c31c54a9afc3
         status: 200 OK
         code: 200
-        duration: 152.336958ms
+        duration: 158.767875ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -326,8 +326,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -335,20 +335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3609
+        content_length: 3146
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "4cd59068-6e30-458f-8ffb-7e4cb9a064d3", "address": "51.15.138.40", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a81c8ac1-c21d-44e5-8760-a207d4f024b2"}, "public_ips": [{"id": "4cd59068-6e30-458f-8ffb-7e4cb9a064d3", "address": "51.15.138.40", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a81c8ac1-c21d-44e5-8760-a207d4f024b2"}], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:11.078847+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:37.311123+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3609"
+                - "3146"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:13 GMT
+                - Fri, 07 Feb 2025 13:54:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,60 +356,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bae654e4-ba36-49b1-80d7-0c20a094f596
+                - eec07036-d733-47b4-ac79-0fe9d4cf4561
         status: 200 OK
         code: 200
-        duration: 169.474959ms
+        duration: 150.927917ms
     - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3609
-        uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "4cd59068-6e30-458f-8ffb-7e4cb9a064d3", "address": "51.15.138.40", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a81c8ac1-c21d-44e5-8760-a207d4f024b2"}, "public_ips": [{"id": "4cd59068-6e30-458f-8ffb-7e4cb9a064d3", "address": "51.15.138.40", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "a81c8ac1-c21d-44e5-8760-a207d4f024b2"}], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:11.078847+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3609"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 13 Jan 2025 09:31:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8666fef2-b5d3-4f02-ae0c-5fe37a8a77e1
-        status: 200 OK
-        code: 200
-        duration: 241.158875ms
-    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -426,8 +377,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c/action
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -437,7 +388,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task": {"id": "ad2d505a-50c3-4e59-b367-e5d0f81a6998", "description": "server_poweroff", "status": "pending", "href_from": "/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c/action", "href_result": "/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c", "started_at": "2025-01-13T09:31:13.989002+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "e6b70b62-8dda-4775-9941-c23e382215c9", "description": "server_poweroff", "status": "pending", "href_from": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action", "href_result": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d", "started_at": "2025-02-07T13:54:40.263602+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -446,11 +397,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:13 GMT
+                - Fri, 07 Feb 2025 13:54:40 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ad2d505a-50c3-4e59-b367-e5d0f81a6998
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/e6b70b62-8dda-4775-9941-c23e382215c9
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -458,10 +409,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 952da932-bba2-45bc-96dc-fb77596eb6cd
+                - 2c118c23-551e-47cc-8ddd-fd79a9377dbd
         status: 202 Accepted
         code: 202
-        duration: 719.06125ms
+        duration: 274.2345ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3106
+        uncompressed: false
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}, "public_ips": [{"id": "74b5a81e-d4bf-4742-843f-2600842d7d79", "address": "163.172.129.187", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "b23327fb-97cb-414f-afd8-92fa8aed6498"}], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3106"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:54:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f41999ce-5530-43fc-bb77-3e61d353b54f
+        status: 200 OK
+        code: 200
+        duration: 132.241959ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -477,8 +477,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -486,20 +486,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3047
+        content_length: 2578
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:13.823817+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3047"
+                - "2578"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:14 GMT
+                - Fri, 07 Feb 2025 13:54:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -507,10 +507,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 122bef91-1d6e-4a2a-bbf8-f2161944929a
+                - f4250d78-7a3f-469e-a1f4-21de0e7bff25
         status: 200 OK
         code: 200
-        duration: 212.896208ms
+        duration: 156.568125ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -526,8 +526,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -535,20 +535,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3047
+        content_length: 2578
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:13.823817+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3047"
+                - "2578"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:19 GMT
+                - Fri, 07 Feb 2025 13:54:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,10 +556,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 326ecdad-b924-4de6-8f2c-b886715dc2d9
+                - 0ebcd96c-1ca0-4ad0-8d1b-755108aede54
         status: 200 OK
         code: 200
-        duration: 181.990667ms
+        duration: 194.662042ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -575,8 +575,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -584,20 +584,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3047
+        content_length: 2578
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:13.823817+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3047"
+                - "2578"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:24 GMT
+                - Fri, 07 Feb 2025 13:54:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58829c4f-223d-4bb1-b1ab-12561e72ef41
+                - b92dd000-6afc-4e87-bd45-09eb00be6904
         status: 200 OK
         code: 200
-        duration: 177.803416ms
+        duration: 295.203333ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3047
+        content_length: 2578
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:13.823817+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3047"
+                - "2578"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:29 GMT
+                - Fri, 07 Feb 2025 13:55:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69ad73a5-9ea8-4881-8227-f11bb972162f
+                - 39907b6f-28ce-41e6-83ca-7d9ac96d0b91
         status: 200 OK
         code: 200
-        duration: 146.530834ms
+        duration: 147.071791ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3047
+        content_length: 2578
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:13.823817+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3047"
+                - "2578"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:35 GMT
+                - Fri, 07 Feb 2025 13:55:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 404e03dc-c0b0-4dab-b7bd-163c753bcaf0
+                - 44ac09a8-e7bc-4244-bb27-ec143213995f
         status: 200 OK
         code: 200
-        duration: 191.620916ms
+        duration: 130.289666ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3047
+        content_length: 2578
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:13.823817+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:54:40.090583+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "20", "hypervisor_id": "601", "node_id": "19"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3047"
+                - "2578"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:40 GMT
+                - Fri, 07 Feb 2025 13:55:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95e81330-c9de-418a-9e74-9da2798d31f4
+                - c21e9596-73e3-4a36-8dda-5f8c027af964
         status: 200 OK
         code: 200
-        duration: 163.002042ms
+        duration: 188.285167ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3047
+        content_length: 2462
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:13.823817+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id": "12", "hypervisor_id": "501", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"server": {"id": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "name": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "hostname": "packer-67a61096-91f3-ff78-2b6a-b57a76dcc715", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "e70056f2-ccfb-4c2a-8077-fb39a023a619", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC8q0A3k9OnA5o28rzCV+hSgbxYAfMnuEoRmT660gByV824i7kN/TV/APz+hOSjBveS6n6yJmSTdJSWzP45oEuOJjqqlbiNhU2zcQZwVGvK0v/BUNrsDIcQHNCCpetLcztDfREDVAuUymMgCOIzGJWDlvtCsbByhUQoSMerehcZu5CXYBFQImVXTA1Yq91nKDoDyAET9ZvTBsebmXODkCcNI0yUHnJ9GaKY+c9ynpfmyncqnPXCN6Gl77xb6snW936ozKwKeneFK0rMqUuMzKE3HN/2R6x0N3gMKA7qaTtQoo4SPLsublOpxEeA3xBBKGAoShoXiI4c22DV/wfXEg6GS/iPJnHjpuO2ERCTB2un+JWII/F4Vpf44He6GsEX5PfWukl8pthWJC2UOYHt8XGyPGhSHjNtHZ3HsjD+pVLbQ/5XXIV9zE5gaYF9hrR+EYaiHp8wpII3Un19bm+oeLEoRQceHTDX8W1/8o+7nRj6KU0j7qumgEj4k3ydCyF7k3pPZMM0ZMN6xD5EfxBmUCMafsgUJUKQP6mBnOUoP/9JJYGmA9RP9SY5jP5OxeKWQMS359Sw4sr/tuJ43O8qIucKwEmbBbyB02RXSLGfbk/HXx5mf5OmeMdVKr3pN5oHqUPOv5pLDyhFWgFX6QS/pd+UsL8CAM7mI5YrW4jmSOXagw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:92:9e:a9", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-02-07T13:54:33.499296+00:00", "modification_date": "2025-02-07T13:55:13.905284+00:00", "bootscript": null, "security_group": {"id": "76c04048-c19b-420b-9576-0f5c9d201d9a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "3047"
+                - "2462"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:45 GMT
+                - Fri, 07 Feb 2025 13:55:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,11 +801,64 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6925dde-d84d-41da-949b-36772be27a13
+                - 5682cba4-2c5e-4703-8598-99f56ca097d0
         status: 200 OK
         code: 200
-        duration: 193.911916ms
+        duration: 121.732584ms
     - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 100
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"backup","name":"packer-e2e-simple","volumes":{"e70056f2-ccfb-4c2a-8077-fb39a023a619":{}}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 351
+        uncompressed: false
+        body: '{"task": {"id": "1e30dd95-afa2-42c0-9a9a-667d3d4a0b27", "description": "instance_backup", "status": "pending", "href_from": "/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d/action", "href_result": "/images/24fcdd8e-b440-4a4f-9328-1e7116fa0e5c", "started_at": "2025-02-07T13:55:17.242110+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "351"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:55:17 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1e30dd95-afa2-42c0-9a9a-667d3d4a0b27
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ee4b1b07-6383-4a39-b280-363cdb3dc120
+        status: 202 Accepted
+        code: 202
+        duration: 579.393709ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -820,8 +873,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/24fcdd8e-b440-4a4f-9328-1e7116fa0e5c
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +882,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2935
+        content_length: 613
         uncompressed: false
-        body: '{"server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "hostname": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00", "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "8b91f397-ca67-4359-a6b7-0c0fadb7b055", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "server": {"id": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "name": "packer-6784dd55-014e-8cfe-e298-d4d936bf312f"}, "size": 10000000000, "state": "available", "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:07.495552+00:00", "tags": [], "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDFxjPw96Mwa7ojJcIDhpX3HbShBQ46L3pZ3iBMatgPH2NQtMbVor4dKP5KeyWShaoukh6XGVs81sglBnFJW3ajB2rl44DS2bO+0tQnFygTXjOb478+MBP/dfmgFkBKy4UzcdVu6NKlneCmgKAi55D52OR+4DPwIQsdg2M/Z+l3WxZ6KPSI/iA45U8MjudefL3yOT0kVfw4F7JApCof5HN6rACeQ9NYuJNIh5Ow8G901rao/XclzQtc6YxCvHxLdiSg22vcTVelew7+aekYEoQDtxRrCkNHJaUu6gR/1ImeV/Hdq41Hw80ek8y+XhNIGy/kONoiCxJ2RnDwlDqr5AfMyQf1ez1xxjm6mzsOuqvw/pvawe2AFmL7PKn8LmBjzCcweaJyHfjjgVVd8AFJRnhOm4B+HMqMN+RPxMb0p4w9PXdNlhOa+A3vbUAytPviZmt9DVAiQofTLpce8Rgc4jjoQPyDhe0HzZ1SUl4wyjftd1YDtRHuQ9Pa6CYMZfUsBtIHiCKmcTzmdJHcTvWvvCkZr1q73BrGcqTg1vNPOo4d004giOgkITd1u69Yct/pMKEdJh1+DOJNxCrItIS5/QycHxNiYo1vNpDYSjRyTTM3awIgy/ZK//p3nHfJsqjGhlkPijkClqzOL3DmjqTuFpvCFeLcEcMh8aVLVECyaW48bw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8c:fe:f3", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-13T09:31:07.495552+00:00", "modification_date": "2025-01-13T09:31:47.303573+00:00", "bootscript": null, "security_group": {"id": "390578d1-6df4-4e36-b1c6-2799cea30746", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+        body: '{"image": {"id": "24fcdd8e-b440-4a4f-9328-1e7116fa0e5c", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f9804316-e919-4840-9f24-71fd727e3262", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:55:16.761993+00:00", "modification_date": "2025-02-07T13:55:16.761993+00:00", "default_bootscript": null, "from_server": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "state": "available", "tags": [], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2935"
+                - "613"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:50 GMT
+                - Fri, 07 Feb 2025 13:55:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,63 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fff0f7b2-5316-4ebe-8551-abe40867e547
+                - 96311f1a-e91c-479e-8a8b-0632017b1ac7
         status: 200 OK
         code: 200
-        duration: 303.572833ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 123
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"action":"backup","name":"packer-e2e-simple","volumes":{"8b91f397-ca67-4359-a6b7-0c0fadb7b055":{"volume_type":"unified"}}}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c/action
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 351
-        uncompressed: false
-        body: '{"task": {"id": "6a2adac3-e3da-4488-b263-8778dc5f5fc9", "description": "instance_backup", "status": "pending", "href_from": "/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c/action", "href_result": "/images/247f2d44-1754-4c88-9130-32dc35bad182", "started_at": "2025-01-13T09:31:51.739993+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "351"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 13 Jan 2025 09:31:51 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6a2adac3-e3da-4488-b263-8778dc5f5fc9
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ab3ef94c-2911-4fbb-8f68-d9b74a4d0ed1
-        status: 202 Accepted
-        code: 202
-        duration: 820.818458ms
+        duration: 82.733416ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,29 +922,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/247f2d44-1754-4c88-9130-32dc35bad182
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1e410c03-4f3e-408f-bd64-afc4761ad60d
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 641
+        content_length: 0
         uncompressed: false
-        body: '{"image": {"id": "247f2d44-1754-4c88-9130-32dc35bad182", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "root_volume": {"id": "ff522daf-6ccd-4d82-aec4-a6b22634ac45", "name": "packer-e2e-simple_snap_0", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-01-13T09:31:51.401650+00:00", "modification_date": "2025-01-13T09:31:51.401650+00:00", "default_bootscript": null, "from_server": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "state": "creating", "tags": [], "zone": "fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "641"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:51 GMT
+                - Fri, 07 Feb 2025 13:55:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +950,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a45d645-3fe3-41b1-bd59-df2c7eaedecc
-        status: 200 OK
-        code: 200
-        duration: 116.0825ms
+                - fa2c061c-86a2-476d-bb58-d3c82ea98a6c
+        status: 204 No Content
+        code: 204
+        duration: 320.961416ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +969,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/247f2d44-1754-4c88-9130-32dc35bad182
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +978,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 642
+        content_length: 143
         uncompressed: false
-        body: '{"image": {"id": "247f2d44-1754-4c88-9130-32dc35bad182", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ac06b5eb-7546-4f57-9ffb-5425d6bb291b", "root_volume": {"id": "ff522daf-6ccd-4d82-aec4-a6b22634ac45", "name": "packer-e2e-simple_snap_0", "volume_type": "unified", "size": 10000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-01-13T09:31:51.401650+00:00", "modification_date": "2025-01-13T09:31:51.401650+00:00", "default_bootscript": null, "from_server": "66c81978-be4c-4e50-9815-95f4cdbd4a8c", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "e70056f2-ccfb-4c2a-8077-fb39a023a619"}'
         headers:
             Content-Length:
-                - "642"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:56 GMT
+                - Fri, 07 Feb 2025 13:55:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +999,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ccc929b-2a1b-4849-95cc-f8a6d710f933
-        status: 200 OK
-        code: 200
-        duration: 356.392084ms
+                - fa964ee9-82a4-4de1-8407-dad641aab793
+        status: 404 Not Found
+        code: 404
+        duration: 43.859166ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1018,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/66c81978-be4c-4e50-9815-95f4cdbd4a8c
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1029,18 +1027,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume", "resource_id": "e70056f2-ccfb-4c2a-8077-fb39a023a619"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:57 GMT
+                - Fri, 07 Feb 2025 13:55:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1048,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37ed28a4-9be2-4559-8bf2-4fb1739dfd3b
-        status: 204 No Content
-        code: 204
-        duration: 350.71025ms
+                - 592085ce-ee32-4f03-9db4-221ec30b86c4
+        status: 404 Not Found
+        code: 404
+        duration: 32.638834ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1067,8 +1067,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.4; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.4; darwin/arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8b91f397-ca67-4359-a6b7-0c0fadb7b055
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 487
+        uncompressed: false
+        body: '{"id":"e70056f2-ccfb-4c2a-8077-fb39a023a619","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:54:33.632945Z","updated_at":"2025-02-07T13:55:17.711695Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"snapshotting","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:55:17.711695Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "487"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:55:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0d93119e-3cee-494c-a525-0895a56e5162
+        status: 200 OK
+        code: 200
+        duration: 54.831583ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 484
+        uncompressed: false
+        body: '{"id":"e70056f2-ccfb-4c2a-8077-fb39a023a619","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"65a3940d-94a0-4a0b-932e-eedae2a6a98e","created_at":"2025-02-07T13:54:33.632945Z","updated_at":"2025-02-07T13:55:17.711695Z","references":[],"parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-02-07T13:55:17.711695Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "484"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 07 Feb 2025 13:55:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d3c54093-79cf-469f-9bec-1d96b6277787
+        status: 200 OK
+        code: 200
+        duration: 57.190125ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.30 (go1.23.5; darwin; arm64) Packer/1.1.1-dev (+https://www.packer.io/; go1.23.5; darwin/arm64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e70056f2-ccfb-4c2a-8077-fb39a023a619
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1085,9 +1183,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Jan 2025 09:31:57 GMT
+                - Fri, 07 Feb 2025 13:55:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1095,7 +1193,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ff6b856-3f88-4638-a43d-9ce23e1bbdfe
+                - 0bfacfeb-b4a7-44ed-8ef6-f0972d339022
         status: 204 No Content
         code: 204
-        duration: 253.631625ms
+        duration: 91.123625ms

--- a/internal/tests/testdata/root-volume-sbs.cassette.yaml
+++ b/internal/tests/testdata/root-volume-sbs.cassette.yaml
@@ -17,7 +17,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-root-volume&page=1&project=b577a333-d52a-4d86-9310-b413d5fe9bb1
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-root-volume-sbs&page=1&project=b577a333-d52a-4d86-9310-b413d5fe9bb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1266
+        content_length: 625
         uncompressed: false
-        body: '{"images": [{"id": "b96d1e58-acac-4f7f-9511-b195d3a6851a", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"id": "3d76deb4-e252-4ac1-b709-6eb4e4698d79", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:38:20.019704+00:00", "modification_date": "2025-02-10T15:38:20.019704+00:00", "default_bootscript": null, "from_server": "b46d82ac-01ae-40c6-8c0e-a37138026141", "state": "available", "tags": [], "zone": "fr-par-1"}, {"id": "a77ece2d-74ac-4c43-bd0d-cf23cac99746", "name": "packer-e2e-root-volume-sbs", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "f3639014-608d-450b-844c-15e19a5a8f4c", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:37:31.116776+00:00", "modification_date": "2025-02-10T15:37:31.116776+00:00", "default_bootscript": null, "from_server": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "a77ece2d-74ac-4c43-bd0d-cf23cac99746", "name": "packer-e2e-root-volume-sbs", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "f3639014-608d-450b-844c-15e19a5a8f4c", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:37:31.116776+00:00", "modification_date": "2025-02-10T15:37:31.116776+00:00", "default_bootscript": null, "from_server": "8122c68c-01b5-46b9-8201-aefe8c91fa98", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
-                - "1266"
+                - "625"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 10 Feb 2025 15:38:27 GMT
+                - Mon, 10 Feb 2025 15:37:34 GMT
             Link:
-                - </images?page=1&per_page=50&name=packer-e2e-root-volume&project=b577a333-d52a-4d86-9310-b413d5fe9bb1>; rel="last"
+                - </images?page=1&per_page=50&name=packer-e2e-root-volume-sbs&project=b577a333-d52a-4d86-9310-b413d5fe9bb1>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d555a643-7faf-4596-ac13-7f071a690b76
+                - 67ff0422-9931-4708-9f6b-a6426a8a3657
             X-Total-Count:
-                - "2"
+                - "1"
         status: 200 OK
         code: 200
-        duration: 588.8825ms
+        duration: 282.97025ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -89,7 +89,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 10 Feb 2025 15:38:27 GMT
+                - Mon, 10 Feb 2025 15:37:34 GMT
             Link:
                 - </volumes?page=0&per_page=100&project=b577a333-d52a-4d86-9310-b413d5fe9bb1>; rel="last"
             Server:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26254c28-50e9-4eb2-86c2-c55d2b704fce
+                - 6a22dd82-7b38-495e-b6e9-37a3c178802a
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 85.636291ms
+        duration: 69.976667ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -142,7 +142,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 10 Feb 2025 15:38:27 GMT
+                - Mon, 10 Feb 2025 15:37:34 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -152,7 +152,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4379af0-196d-468a-ada3-b09a6bb356d1
+                - f8465e19-f2d8-40db-9005-2f0588bc0b85
         status: 200 OK
         code: 200
-        duration: 42.082542ms
+        duration: 38.162167ms

--- a/internal/tests/testdata/root-volume.cassette.yaml
+++ b/internal/tests/testdata/root-volume.cassette.yaml
@@ -17,7 +17,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-simple&page=1&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-root-volume&page=1&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
         method: GET
       response:
         proto: HTTP/2.0
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 616
+        content_length: 653
         uncompressed: false
-        body: '{"images": [{"id": "24fcdd8e-b440-4a4f-9328-1e7116fa0e5c", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f9804316-e919-4840-9f24-71fd727e3262", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:55:16.761993+00:00", "modification_date": "2025-02-07T13:55:16.761993+00:00", "default_bootscript": null, "from_server": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "851ed46e-aa23-4733-8610-6e0b36d6147e", "name": "packer-e2e-root-volume", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"id": "71d3b9eb-8fab-484d-b59e-28c7929bcb3b", "name": "packer-e2e-root-volume_snap_0", "volume_type": "b_ssd", "size": 50000000000}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:54:22.625071+00:00", "modification_date": "2025-02-07T13:54:22.625071+00:00", "default_bootscript": null, "from_server": "4ac3b748-b2e1-4332-a59e-9725c41c8d1c", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
-                - "616"
+                - "653"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:24 GMT
+                - Fri, 07 Feb 2025 13:54:30 GMT
             Link:
-                - </images?page=1&per_page=50&name=packer-e2e-simple&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
+                - </images?page=1&per_page=50&name=packer-e2e-root-volume&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ffbabd2-00fb-4b05-82cf-0352ccde1e18
+                - ea3032d3-f1e9-46f4-8e75-6b42e8ec0608
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 244.67875ms
+        duration: 184.252625ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:24 GMT
+                - Fri, 07 Feb 2025 13:54:30 GMT
             Link:
                 - </volumes?page=0&per_page=100&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e228d6d-3674-4d8a-97f1-9346dd028aed
+                - a03420d1-9865-4f6d-921e-fa3814b6dcc7
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 61.359042ms
+        duration: 81.201041ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -142,9 +142,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:24 GMT
+                - Fri, 07 Feb 2025 13:54:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,7 +152,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc48e74b-aa4d-47ce-ba1e-77bd8479fd72
+                - 2aa941bc-5b43-47f4-ac6a-659e8bf912e5
         status: 200 OK
         code: 200
-        duration: 40.992792ms
+        duration: 70.300375ms

--- a/internal/tests/testdata/simple.cassette.yaml
+++ b/internal/tests/testdata/simple.cassette.yaml
@@ -17,7 +17,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-simple&page=1&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-simple&page=1&project=b577a333-d52a-4d86-9310-b413d5fe9bb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -27,7 +27,7 @@ interactions:
         trailer: {}
         content_length: 616
         uncompressed: false
-        body: '{"images": [{"id": "24fcdd8e-b440-4a4f-9328-1e7116fa0e5c", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "65a3940d-94a0-4a0b-932e-eedae2a6a98e", "root_volume": {"volume_type": "sbs_snapshot", "id": "f9804316-e919-4840-9f24-71fd727e3262", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-07T13:55:16.761993+00:00", "modification_date": "2025-02-07T13:55:16.761993+00:00", "default_bootscript": null, "from_server": "1e410c03-4f3e-408f-bd64-afc4761ad60d", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "ec860961-5a7e-4126-9c69-af4591d076f0", "name": "packer-e2e-simple", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "b577a333-d52a-4d86-9310-b413d5fe9bb1", "root_volume": {"volume_type": "sbs_snapshot", "id": "3a172cdf-c167-4979-b8fb-9e1a77eec206", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-02-10T15:39:15.062024+00:00", "modification_date": "2025-02-10T15:39:15.062024+00:00", "default_bootscript": null, "from_server": "e2813b3a-bf1f-4a1b-887d-8bd54c63d0b7", "state": "available", "tags": [], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
                 - "616"
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:24 GMT
+                - Mon, 10 Feb 2025 15:39:16 GMT
             Link:
-                - </images?page=1&per_page=50&name=packer-e2e-simple&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
+                - </images?page=1&per_page=50&name=packer-e2e-simple&project=b577a333-d52a-4d86-9310-b413d5fe9bb1>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ffbabd2-00fb-4b05-82cf-0352ccde1e18
+                - 30850a63-0859-4be8-838d-c732781223d9
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 244.67875ms
+        duration: 152.757292ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=65a3940d-94a0-4a0b-932e-eedae2a6a98e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=b577a333-d52a-4d86-9310-b413d5fe9bb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:24 GMT
+                - Mon, 10 Feb 2025 15:39:17 GMT
             Link:
-                - </volumes?page=0&per_page=100&project=65a3940d-94a0-4a0b-932e-eedae2a6a98e>; rel="last"
+                - </volumes?page=0&per_page=100&project=b577a333-d52a-4d86-9310-b413d5fe9bb1>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e228d6d-3674-4d8a-97f1-9346dd028aed
+                - 783998cd-60cd-455a-9472-21d8f068a85c
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 61.359042ms
+        duration: 83.814792ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=65a3940d-94a0-4a0b-932e-eedae2a6a98e
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes?order_by=created_at_asc&project_id=b577a333-d52a-4d86-9310-b413d5fe9bb1
         method: GET
       response:
         proto: HTTP/2.0
@@ -142,9 +142,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 07 Feb 2025 13:55:24 GMT
+                - Mon, 10 Feb 2025 15:39:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,7 +152,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc48e74b-aa4d-47ce-ba1e-77bd8479fd72
+                - 387707af-cfa8-434e-b672-05fe94780e05
         status: 200 OK
         code: 200
-        duration: 40.992792ms
+        duration: 54.427167ms


### PR DESCRIPTION
Closes #210 

As requested by our product, root volume now default to sbs. Unless `b_ssd` is specified, Image will be created on SBS.