### PR TITLE
feat: format invalid precondition failed error

### DIFF
--- a/builder/scaleway/api.go
+++ b/builder/scaleway/api.go
@@ -1,6 +1,8 @@
 package scaleway
 
 import (
+	"encoding/json"
+	"errors"
 	_ "unsafe" // Import required for link
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
@@ -9,3 +11,21 @@ import (
 
 //go:linkname createServer github.com/scaleway/scaleway-sdk-go/api/instance/v1.(*API).createServer
 func createServer(*instance.API, *instance.CreateServerRequest, ...scw.RequestOption) (*instance.CreateServerResponse, error)
+
+func newResponseErrorFromBody(rawBody []byte) error {
+	responseError := scw.ResponseError{}
+	_ = json.Unmarshal(rawBody, &responseError)
+
+	return &responseError
+}
+
+// formatNonStandardError provides a way to format non-standard errors returned by instance's API.
+// If error is not detected as non-standard, format will be no-op.
+func formatInstanceError(err error) error {
+	preconditionFailedError := &scw.PreconditionFailedError{}
+	if errors.As(err, &preconditionFailedError) && preconditionFailedError.Precondition == "" {
+		return newResponseErrorFromBody(preconditionFailedError.RawBody)
+	}
+
+	return err
+}

--- a/builder/scaleway/step_create_server.go
+++ b/builder/scaleway/step_create_server.go
@@ -83,7 +83,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 
 	createServerResp, err := createServer(instanceAPI, createServerReq, scw.WithContext(ctx))
 	if err != nil {
-		err := fmt.Errorf("error creating server: %w", err)
+		err := fmt.Errorf("error creating server: %w", formatInstanceError(err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 


### PR DESCRIPTION
Instance returns errors that do not respect scaleway's errors format.
If we detect that an error miss required field, this means that the error should be used as an unknown response error to avoid losing help messages.