### PR TITLE
fix(config): override project_id only if empty

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -78,6 +78,7 @@ type Config struct {
 	// PLAY2-PICO, PLAY2-NANO, PLAY2-MICRO,
 	// PRO2-XXS, PRO2-XS, PRO2-S, PRO2-M, PRO2-L,
 	// GP1-XS, GP1-S, GP1-M, GP1-L, GP1-XL,
+	// ENT1-XXS, ENT1-XS, ENT1-S, ENT1-M, ENT1-L, ENT1-XL, ENT1-2XL,
 	// GPU-3070-S, RENDER-S, STARDUST1-S,
 	CommercialType string `mapstructure:"commercial_type" required:"true"`
 	// The name of the resulting snapshot that will

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -78,7 +78,6 @@ type Config struct {
 	// PLAY2-PICO, PLAY2-NANO, PLAY2-MICRO,
 	// PRO2-XXS, PRO2-XS, PRO2-S, PRO2-M, PRO2-L,
 	// GP1-XS, GP1-S, GP1-M, GP1-L, GP1-XL,
-	// ENT1-XXS, ENT1-XS, ENT1-S, ENT1-M, ENT1-L, ENT1-XL, ENT1-2XL,
 	// GPU-3070-S, RENDER-S, STARDUST1-S,
 	CommercialType string `mapstructure:"commercial_type" required:"true"`
 	// The name of the resulting snapshot that will
@@ -205,7 +204,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) { //nolint:gocyc
 		}
 	}
 
-	if c.Organization != "" {
+	if c.Organization != "" && c.ProjectID == "" && profile.DefaultProjectID == nil {
 		warnings = append(warnings, "organization_id is deprecated in favor of project_id")
 		c.ProjectID = c.Organization
 	}


### PR DESCRIPTION
Since `organization_id` is deprecated, its value should not override `project_id` unless no value was provided for this field in the packer configuration file, in the active profile or in the environment.

Closes #242 

