### PR TITLE
feat: remove `image_size_in_gb` argument

### DIFF
--- a/.web-docs/components/builder/scaleway/README.md
+++ b/.web-docs/components/builder/scaleway/README.md
@@ -71,8 +71,6 @@ can also be supplied to override the typical auto-generated key:
   Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_API_URL
 
-- `image_size_in_gb` (int32) - The Image size in GB. Will only work for images based on block volumes.
-
 - `snapshot_name` (string) - The name of the resulting snapshot that will
   appear in your account. Default packer-TIMESTAMP
 

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -71,8 +71,6 @@ type Config struct {
 	// get the complete list of the accepted image UUID.
 	// The marketplace image label (eg `ubuntu_focal`) also works.
 	Image string `mapstructure:"image" required:"true"`
-	// The Image size in GB. Will only work for images based on block volumes.
-	ImageSizeInGB int32 `mapstructure:"image_size_in_gb" required:"false"`
 	// The name of the server commercial type:
 	// DEV1-S, DEV1-M, DEV1-L, DEV1-XL,
 	// PLAY2-PICO, PLAY2-NANO, PLAY2-MICRO,

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -73,7 +73,6 @@ type FlatConfig struct {
 	Zone                      *string                 `mapstructure:"zone" required:"true" cty:"zone" hcl:"zone"`
 	APIURL                    *string                 `mapstructure:"api_url" cty:"api_url" hcl:"api_url"`
 	Image                     *string                 `mapstructure:"image" required:"true" cty:"image" hcl:"image"`
-	ImageSizeInGB             *int32                  `mapstructure:"image_size_in_gb" required:"false" cty:"image_size_in_gb" hcl:"image_size_in_gb"`
 	CommercialType            *string                 `mapstructure:"commercial_type" required:"true" cty:"commercial_type" hcl:"commercial_type"`
 	SnapshotName              *string                 `mapstructure:"snapshot_name" required:"false" cty:"snapshot_name" hcl:"snapshot_name"`
 	ImageName                 *string                 `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
@@ -171,7 +170,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"zone":                         &hcldec.AttrSpec{Name: "zone", Type: cty.String, Required: false},
 		"api_url":                      &hcldec.AttrSpec{Name: "api_url", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
-		"image_size_in_gb":             &hcldec.AttrSpec{Name: "image_size_in_gb", Type: cty.Number, Required: false},
 		"commercial_type":              &hcldec.AttrSpec{Name: "commercial_type", Type: cty.String, Required: false},
 		"snapshot_name":                &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},

--- a/builder/scaleway/step_create_server.go
+++ b/builder/scaleway/step_create_server.go
@@ -44,16 +44,6 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 		Zone:           scw.Zone(c.Zone),
 	}
 
-	if c.ImageSizeInGB != 0 {
-		size := scw.Size(c.ImageSizeInGB) * scw.GB
-		createServerReq.Volumes = map[string]*instance.VolumeServerTemplate{
-			"0": {
-				VolumeType: instance.VolumeVolumeTypeBSSD,
-				Size:       &size,
-			},
-		}
-	}
-
 	if c.RootVolume.IsConfigured() {
 		if createServerReq.Volumes == nil {
 			createServerReq.Volumes = make(map[string]*instance.VolumeServerTemplate)

--- a/docs-partials/builder/scaleway/Config-not-required.mdx
+++ b/docs-partials/builder/scaleway/Config-not-required.mdx
@@ -4,8 +4,6 @@
   Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_API_URL
 
-- `image_size_in_gb` (int32) - The Image size in GB. Will only work for images based on block volumes.
-
 - `snapshot_name` (string) - The name of the resulting snapshot that will
   appear in your account. Default packer-TIMESTAMP
 

--- a/internal/tests/complete_test.go
+++ b/internal/tests/complete_test.go
@@ -10,6 +10,9 @@ import (
 
 func TestComplete(t *testing.T) {
 	t.Skip("snapshot_name argument does not work")
+	// This test won't work as it is because b_ssd volumes are no longer supported. This means that the volume that gets
+	// created by default is now an SBS volume, and the check functions only work for Instance Block Volumes.
+	// To reactivate it, we will need to write new check functions for SBS volumes.
 
 	zone := scw.ZoneFrPar2
 
@@ -24,7 +27,6 @@ source "scaleway" "basic" {
   ssh_username = "root"
 
   remove_volume = false
-  image_size_in_gb = 42
   snapshot_name = "packer-e2e-complete-snapshot"
 }
 


### PR DESCRIPTION
The `image_size_in_gb` argument was only useful for volumes of type `b_ssd`, which are no longer supported, so we should remove it.

Closes #112 

